### PR TITLE
feat: handle consistent Start/Stop/Restart status handling

### DIFF
--- a/src/ClrProfiler.DatadogTracing/ClrTracker.cs
+++ b/src/ClrProfiler.DatadogTracing/ClrTracker.cs
@@ -63,6 +63,13 @@ public class ClrTracker
         ProfilerTracker.Current.Value.Stop();
     }
 
+    public void RestartTracker()
+    {
+        if (!_enabled) return;
+        _logger.LogDebug($"Restart tracking {nameof(ClrTracker)}");
+        ProfilerTracker.Current.Value.Restart();
+    }
+
     public void CancelTracker()
     {
         if (!_enabled) return;

--- a/src/ClrProfiler/EventListeners/ContentionEventListener.cs
+++ b/src/ClrProfiler/EventListeners/ContentionEventListener.cs
@@ -56,16 +56,22 @@ public class ContentionEventListener : ProfileEventListenerBase, IChannelReader
 
     public async ValueTask OnReadResultAsync(CancellationToken cancellationToken = default)
     {
-        // read from channel
-        while (Enabled && await _channel.Reader.WaitToReadAsync(cancellationToken))
+        try
         {
-            while (Enabled && _channel.Reader.TryRead(out var value))
+            // Keep the reader alive across Stop/Restart. Cancellation owns its lifetime.
+            while (await _channel.Reader.WaitToReadAsync(cancellationToken))
             {
-                if (_onEventEmit != null)
+                while (_channel.Reader.TryRead(out var value))
                 {
-                    await _onEventEmit.Invoke(value);
+                    if (_onEventEmit != null)
+                    {
+                        await _onEventEmit.Invoke(value);
+                    }
                 }
             }
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
         }
     }
 }

--- a/src/ClrProfiler/EventListeners/ContentionEventListener.cs
+++ b/src/ClrProfiler/EventListeners/ContentionEventListener.cs
@@ -65,7 +65,14 @@ public class ContentionEventListener : ProfileEventListenerBase, IChannelReader
                 {
                     if (_onEventEmit != null)
                     {
-                        await _onEventEmit.Invoke(value);
+                        try
+                        {
+                            await _onEventEmit.Invoke(value);
+                        }
+                        catch (Exception ex)
+                        {
+                            _onEventError.Invoke(ex);
+                        }
                     }
                 }
             }

--- a/src/ClrProfiler/EventListeners/GCEventListener.cs
+++ b/src/ClrProfiler/EventListeners/GCEventListener.cs
@@ -132,7 +132,14 @@ public class GCEventListener : ProfileEventListenerBase, IChannelReader
                 {
                     if (_onEventEmit != null)
                     {
-                        await _onEventEmit.Invoke(value);
+                        try
+                        {
+                            await _onEventEmit.Invoke(value);
+                        }
+                        catch (Exception ex)
+                        {
+                            _onEventError.Invoke(ex);
+                        }
                     }
                 }
             }

--- a/src/ClrProfiler/EventListeners/GCEventListener.cs
+++ b/src/ClrProfiler/EventListeners/GCEventListener.cs
@@ -123,16 +123,22 @@ public class GCEventListener : ProfileEventListenerBase, IChannelReader
 
     public async ValueTask OnReadResultAsync(CancellationToken cancellationToken = default)
     {
-        // read from channel
-        while (Enabled && await _channel.Reader.WaitToReadAsync(cancellationToken))
+        try
         {
-            while (Enabled && _channel.Reader.TryRead(out var value))
+            // Keep the reader alive across Stop/Restart. Cancellation owns its lifetime.
+            while (await _channel.Reader.WaitToReadAsync(cancellationToken))
             {
-                if (_onEventEmit != null)
+                while (_channel.Reader.TryRead(out var value))
                 {
-                    await _onEventEmit.Invoke(value);
+                    if (_onEventEmit != null)
+                    {
+                        await _onEventEmit.Invoke(value);
+                    }
                 }
             }
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
         }
     }
 }

--- a/src/ClrProfiler/EventListeners/ThreadPoolEventListener.cs
+++ b/src/ClrProfiler/EventListeners/ThreadPoolEventListener.cs
@@ -75,16 +75,22 @@ public class ThreadPoolEventListener : ProfileEventListenerBase, IChannelReader
 
     public async ValueTask OnReadResultAsync(CancellationToken cancellationToken = default)
     {
-        // read from channel
-        while (Enabled && await _channel.Reader.WaitToReadAsync(cancellationToken))
+        try
         {
-            while (Enabled && _channel.Reader.TryRead(out var value))
+            // Keep the reader alive across Stop/Restart. Cancellation owns its lifetime.
+            while (await _channel.Reader.WaitToReadAsync(cancellationToken))
             {
-                if (_onEventEmit != null)
+                while (_channel.Reader.TryRead(out var value))
                 {
-                    await _onEventEmit.Invoke(value);
+                    if (_onEventEmit != null)
+                    {
+                        await _onEventEmit.Invoke(value);
+                    }
                 }
             }
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
         }
     }
 }

--- a/src/ClrProfiler/EventListeners/ThreadPoolEventListener.cs
+++ b/src/ClrProfiler/EventListeners/ThreadPoolEventListener.cs
@@ -84,7 +84,14 @@ public class ThreadPoolEventListener : ProfileEventListenerBase, IChannelReader
                 {
                     if (_onEventEmit != null)
                     {
-                        await _onEventEmit.Invoke(value);
+                        try
+                        {
+                            await _onEventEmit.Invoke(value);
+                        }
+                        catch (Exception ex)
+                        {
+                            _onEventError.Invoke(ex);
+                        }
                     }
                 }
             }

--- a/src/ClrProfiler/ProfilerTracker.cs
+++ b/src/ClrProfiler/ProfilerTracker.cs
@@ -44,6 +44,14 @@ public class ProfilerTrackerOptions
 
 public class ProfilerTracker
 {
+    private enum TrackerState
+    {
+        NotStarted,
+        Running,
+        Stopped,
+        Cancelled,
+    }
+
     /// <summary>
     /// Singleton instance access.
     /// </summary>
@@ -55,12 +63,12 @@ public class ProfilerTracker
     public static ProfilerTrackerOptions Options { get; set; } = new ProfilerTrackerOptions();
 
     private readonly IProfiler[] profilerStats;
-    private int initializedNum;
+    private readonly Task?[] readerTasks;
+    private readonly object lifecycleLock = new();
+    private TrackerState state = TrackerState.NotStarted;
 
     private ProfilerTracker()
-    {
-        // list Stats
-        profilerStats = [
+        : this([
             // event
             new GCEventProfiler(Options.GCEventCallback.OnSuccess, Options.GCEventCallback.OnError),
             new ThreadPoolEventProfiler(Options.ThreadPoolEventCallback.OnSuccess, Options.ThreadPoolEventCallback.OnError),
@@ -69,7 +77,14 @@ public class ProfilerTracker
             new ThreadInfoTimerProfiler(Options.ThreadInfoTimerCallback.OnSuccess, Options.ThreadInfoTimerCallback.OnError, Options.TimerOption),
             new GCInfoTimerProfiler(Options.GCInfoTimerCallback.OnSuccess, Options.GCInfoTimerCallback.OnError, Options.TimerOption),
             new ProcessInfoTimerProfiler(Options.ProcessInfoTimerCallback.OnSuccess, Options.ProcessInfoTimerCallback.OnError, Options.TimerOption),
-        ];
+        ])
+    {
+    }
+
+    internal ProfilerTracker(IProfiler[] profilers)
+    {
+        profilerStats = profilers;
+        readerTasks = new Task?[profilers.Length];
     }
 
     /// <summary>
@@ -77,18 +92,28 @@ public class ProfilerTracker
     /// </summary>
     public void Start()
     {
-        // offer thread safe single access
-        Interlocked.Increment(ref initializedNum);
-        if (initializedNum != 1) return;
-
-        // reset initialization status if cancelled.
-        Options.CancellationTokenSource.Token.Register(() => initializedNum = 0);
-
-        foreach (var profile in profilerStats)
+        lock (lifecycleLock)
         {
-            profile.Start();
-            // FireAndForget
-            _ = profile.ReadResultAsync(Options.CancellationTokenSource.Token);
+            if (state == TrackerState.Running || state == TrackerState.Cancelled) return;
+
+            if (state == TrackerState.Stopped)
+            {
+                state = TrackerState.Running;
+                foreach (var profile in profilerStats)
+                {
+                    profile.Restart();
+                }
+                return;
+            }
+
+            state = TrackerState.Running;
+            for (var i = 0; i < profilerStats.Length; i++)
+            {
+                // Keep one reader alive until cancellation so Stop/Restart does not lose it.
+                var profile = profilerStats[i];
+                readerTasks[i] = profile.ReadResultAsync(Options.CancellationTokenSource.Token);
+                profile.Start();
+            }
         }
     }
     /// <summary>
@@ -96,11 +121,15 @@ public class ProfilerTracker
     /// </summary>
     public void Restart()
     {
-        if (initializedNum != 1) return;
-
-        foreach (var stat in profilerStats)
+        lock (lifecycleLock)
         {
-            stat.Restart();
+            if (state != TrackerState.Stopped) return;
+
+            state = TrackerState.Running;
+            foreach (var stat in profilerStats)
+            {
+                stat.Restart();
+            }
         }
     }
     /// <summary>
@@ -108,11 +137,15 @@ public class ProfilerTracker
     /// </summary>
     public void Stop()
     {
-        if (initializedNum != 1) return;
-
-        foreach (var stat in profilerStats)
+        lock (lifecycleLock)
         {
-            stat.Stop();
+            if (state != TrackerState.Running) return;
+
+            state = TrackerState.Stopped;
+            foreach (var stat in profilerStats)
+            {
+                stat.Stop();
+            }
         }
     }
 
@@ -121,7 +154,22 @@ public class ProfilerTracker
     /// </summary>
     public void Cancel()
     {
-        Options.CancellationTokenSource.Cancel();
+        CancellationTokenSource cancellationTokenSource;
+        lock (lifecycleLock)
+        {
+            if (state == TrackerState.Cancelled) return;
+
+            if (state == TrackerState.Running)
+            {
+                foreach (var stat in profilerStats)
+                {
+                    stat.Stop();
+                }
+            }
+            state = TrackerState.Cancelled;
+            cancellationTokenSource = Options.CancellationTokenSource;
+        }
+        cancellationTokenSource.Cancel();
     }
 
     /// <summary>
@@ -131,12 +179,16 @@ public class ProfilerTracker
     /// <param name="cts"></param>
     public bool Reset(CancellationTokenSource cts)
     {
-        if (Options.CancellationTokenSource.IsCancellationRequested)
+        lock (lifecycleLock)
         {
+            if (state != TrackerState.Cancelled) return false;
+            if (!Options.CancellationTokenSource.IsCancellationRequested) return false;
+            if (readerTasks.Any(task => task is not null && !task.IsCompleted)) return false;
+
             Options.CancellationTokenSource = cts;
+            state = TrackerState.NotStarted;
             return true;
         }
-        return false;
     }
 
     /// <summary>

--- a/src/ClrProfiler/TimerListeners/GCInfoTimerListener.cs
+++ b/src/ClrProfiler/TimerListeners/GCInfoTimerListener.cs
@@ -69,16 +69,22 @@ public class GCInfoTimerListener : TimerListenerBase, IDisposable, IChannelReade
 
     public async ValueTask OnReadResultAsync(CancellationToken cancellationToken)
     {
-        // read from channel
-        while (Enabled && await _channel.Reader.WaitToReadAsync(cancellationToken))
+        try
         {
-            while (Enabled && _channel.Reader.TryRead(out var value))
+            // Keep the reader alive across Stop/Restart. Cancellation owns its lifetime.
+            while (await _channel.Reader.WaitToReadAsync(cancellationToken))
             {
-                if (_onEventEmit != null)
+                while (_channel.Reader.TryRead(out var value))
                 {
-                    await _onEventEmit.Invoke(value);
+                    if (_onEventEmit != null)
+                    {
+                        await _onEventEmit.Invoke(value);
+                    }
                 }
             }
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
         }
     }
 

--- a/src/ClrProfiler/TimerListeners/GCInfoTimerListener.cs
+++ b/src/ClrProfiler/TimerListeners/GCInfoTimerListener.cs
@@ -78,7 +78,14 @@ public class GCInfoTimerListener : TimerListenerBase, IDisposable, IChannelReade
                 {
                     if (_onEventEmit != null)
                     {
-                        await _onEventEmit.Invoke(value);
+                        try
+                        {
+                            await _onEventEmit.Invoke(value);
+                        }
+                        catch (Exception ex)
+                        {
+                            _onEventError.Invoke(ex);
+                        }
                     }
                 }
             }

--- a/src/ClrProfiler/TimerListeners/ProcessInfoTimerListener.cs
+++ b/src/ClrProfiler/TimerListeners/ProcessInfoTimerListener.cs
@@ -75,7 +75,14 @@ public class ProcessInfoTimerListener : TimerListenerBase, IDisposable, IChannel
                 {
                     if (_onEventEmit != null)
                     {
-                        await _onEventEmit.Invoke(value);
+                        try
+                        {
+                            await _onEventEmit.Invoke(value);
+                        }
+                        catch (Exception ex)
+                        {
+                            _onEventError.Invoke(ex);
+                        }
                     }
                 }
             }

--- a/src/ClrProfiler/TimerListeners/ProcessInfoTimerListener.cs
+++ b/src/ClrProfiler/TimerListeners/ProcessInfoTimerListener.cs
@@ -66,16 +66,22 @@ public class ProcessInfoTimerListener : TimerListenerBase, IDisposable, IChannel
 
     public async ValueTask OnReadResultAsync(CancellationToken cancellationToken)
     {
-        // read from channel
-        while (Enabled && await _channel.Reader.WaitToReadAsync(cancellationToken))
+        try
         {
-            while (Enabled && _channel.Reader.TryRead(out var value))
+            // Keep the reader alive across Stop/Restart. Cancellation owns its lifetime.
+            while (await _channel.Reader.WaitToReadAsync(cancellationToken))
             {
-                if (_onEventEmit != null)
+                while (_channel.Reader.TryRead(out var value))
                 {
-                    await _onEventEmit.Invoke(value);
+                    if (_onEventEmit != null)
+                    {
+                        await _onEventEmit.Invoke(value);
+                    }
                 }
             }
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
         }
     }
 

--- a/src/ClrProfiler/TimerListeners/ThreadInfoTimerListener.cs
+++ b/src/ClrProfiler/TimerListeners/ThreadInfoTimerListener.cs
@@ -59,16 +59,22 @@ public class ThreadInfoTimerListener : TimerListenerBase, IDisposable, IChannelR
 
     public async ValueTask OnReadResultAsync(CancellationToken cancellationToken)
     {
-        // read from channel
-        while (Enabled && await _channel.Reader.WaitToReadAsync(cancellationToken))
+        try
         {
-            while (Enabled && _channel.Reader.TryRead(out var value))
+            // Keep the reader alive across Stop/Restart. Cancellation owns its lifetime.
+            while (await _channel.Reader.WaitToReadAsync(cancellationToken))
             {
-                if (_onEventEmit != null)
+                while (_channel.Reader.TryRead(out var value))
                 {
-                    await _onEventEmit.Invoke(value);
+                    if (_onEventEmit != null)
+                    {
+                        await _onEventEmit.Invoke(value);
+                    }
                 }
             }
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
         }
     }
 

--- a/src/ClrProfiler/TimerListeners/ThreadInfoTimerListener.cs
+++ b/src/ClrProfiler/TimerListeners/ThreadInfoTimerListener.cs
@@ -68,7 +68,14 @@ public class ThreadInfoTimerListener : TimerListenerBase, IDisposable, IChannelR
                 {
                     if (_onEventEmit != null)
                     {
-                        await _onEventEmit.Invoke(value);
+                        try
+                        {
+                            await _onEventEmit.Invoke(value);
+                        }
+                        catch (Exception ex)
+                        {
+                            _onEventError.Invoke(ex);
+                        }
                     }
                 }
             }

--- a/tests/ClrProfiler.UnitTest/EventListenerDataIntegrityTest.cs
+++ b/tests/ClrProfiler.UnitTest/EventListenerDataIntegrityTest.cs
@@ -13,13 +13,14 @@ public class EventListenerDataIntegrityTest
     public async Task GCEventListenerPreservesEveryEventAtChannelCapacity()
     {
         var actual = new List<GCEventStatistics>(ChannelCapacity);
+        using var cts = new CancellationTokenSource(TestTimeout);
         TestableGCEventListener? listener = null;
         listener = new TestableGCEventListener(value =>
         {
             actual.Add(value);
             if (actual.Count == ChannelCapacity)
             {
-                listener!.DisableReading();
+                cts.Cancel();
             }
             return Task.CompletedTask;
         });
@@ -40,7 +41,6 @@ public class EventListenerDataIntegrityTest
             }
 
             listener.EnableReading();
-            using var cts = new CancellationTokenSource(TestTimeout);
             await listener.OnReadResultAsync(cts.Token);
         }
 
@@ -67,13 +67,14 @@ public class EventListenerDataIntegrityTest
     public async Task ContentionEventListenerPreservesEveryEventAtChannelCapacity()
     {
         var actual = new List<ContentionEventStatistics>(ChannelCapacity);
+        using var cts = new CancellationTokenSource(TestTimeout);
         TestableContentionEventListener? listener = null;
         listener = new TestableContentionEventListener(value =>
         {
             actual.Add(value);
             if (actual.Count == ChannelCapacity)
             {
-                listener!.DisableReading();
+                cts.Cancel();
             }
             return Task.CompletedTask;
         });
@@ -86,7 +87,6 @@ public class EventListenerDataIntegrityTest
             }
 
             listener.EnableReading();
-            using var cts = new CancellationTokenSource(TestTimeout);
             await listener.OnReadResultAsync(cts.Token);
         }
 
@@ -102,13 +102,14 @@ public class EventListenerDataIntegrityTest
     public async Task ThreadPoolEventListenerPreservesEveryTrackedEventAtChannelCapacity()
     {
         var actual = new List<ThreadPoolEventStatistics>(ChannelCapacity);
+        using var cts = new CancellationTokenSource(TestTimeout);
         TestableThreadPoolEventListener? listener = null;
         listener = new TestableThreadPoolEventListener(value =>
         {
             actual.Add(value);
             if (actual.Count == ChannelCapacity)
             {
-                listener!.DisableReading();
+                cts.Cancel();
             }
             return Task.CompletedTask;
         });
@@ -126,7 +127,6 @@ public class EventListenerDataIntegrityTest
             listener.ProcessEvent("ThreadPoolWorkerThreadWait", origin, []);
 
             listener.EnableReading();
-            using var cts = new CancellationTokenSource(TestTimeout);
             await listener.OnReadResultAsync(cts.Token);
         }
 

--- a/tests/ClrProfiler.UnitTest/GcProfilerUnitTest.cs
+++ b/tests/ClrProfiler.UnitTest/GcProfilerUnitTest.cs
@@ -6,7 +6,7 @@ namespace ClrProfiler.UnitTest;
 public class GcProfilerUnitTest
 {
     [Fact, TestPriority(0)]
-    public void GCInfoTimerProfilerTest()
+    public async Task GCInfoTimerProfilerTest()
     {
         var before = GC.GetTotalAllocatedBytes(true);
         using var cts = new CancellationTokenSource();
@@ -35,7 +35,7 @@ public class GcProfilerUnitTest
         // RunProfile
         var before2 = GC.GetTotalAllocatedBytes(true);
         profiler.Start();
-        _ = profiler.ReadResultAsync(cts.Token);
+        var readerTask = profiler.ReadResultAsync(cts.Token);
         while (!complete)
         {
             Thread.Sleep(50);
@@ -60,7 +60,6 @@ public class GcProfilerUnitTest
 
         // 1
         profiler.Start();
-        _ = profiler.ReadResultAsync(cts.Token);
         GC.Collect(2, GCCollectionMode.Forced, true, true);
         gen0GCCount++;
         gen1GCCount++;
@@ -79,7 +78,6 @@ public class GcProfilerUnitTest
 
         // 2
         profiler.Start();
-        _ = profiler.ReadResultAsync(cts.Token);
         GC.Collect(2, GCCollectionMode.Forced, true, true);
         gen0GCCount++;
         gen1GCCount++;
@@ -97,5 +95,6 @@ public class GcProfilerUnitTest
         //Assert.Equal(24, actual.Gen0Size);
 
         cts.Cancel();
+        await readerTask;
     }
 }

--- a/tests/ClrProfiler.UnitTest/ProfilerLifecycleTest.cs
+++ b/tests/ClrProfiler.UnitTest/ProfilerLifecycleTest.cs
@@ -128,6 +128,66 @@ public class ProfilerLifecycleTest
         Assert.Equal(2, count);
     }
 
+    [Fact]
+    public async Task EventReaderReportsCallbackExceptionAndContinues()
+    {
+        using var cts = new CancellationTokenSource(TestTimeout);
+        var expectedException = new InvalidOperationException("callback failed");
+        var reportedException = new TaskCompletionSource<Exception>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var nextEvent = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var count = 0;
+        using var listener = new TestableContentionEventListener(_ =>
+        {
+            if (Interlocked.Increment(ref count) == 1)
+            {
+                return Task.FromException(expectedException);
+            }
+            nextEvent.TrySetResult();
+            return Task.CompletedTask;
+        }, exception => reportedException.TrySetResult(exception));
+
+        listener.EnableReading();
+        var readerTask = listener.OnReadResultAsync(cts.Token).AsTask();
+        listener.ProcessEvent("ContentionStop_V1", DateTime.UtcNow, [0U, 0U, 1.0]);
+        listener.ProcessEvent("ContentionStop_V1", DateTime.UtcNow, [1U, 0U, 2.0]);
+
+        Assert.Same(expectedException, await reportedException.Task.WaitAsync(TestTimeout));
+        await nextEvent.Task.WaitAsync(TestTimeout);
+        cts.Cancel();
+        await readerTask;
+        Assert.Equal(2, count);
+    }
+
+    [Fact]
+    public async Task TimerReaderReportsCallbackExceptionAndContinues()
+    {
+        using var cts = new CancellationTokenSource(TestTimeout);
+        var expectedException = new InvalidOperationException("callback failed");
+        var reportedException = new TaskCompletionSource<Exception>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var nextSample = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var count = 0;
+        using var listener = new TestableThreadInfoTimerListener(_ =>
+        {
+            if (Interlocked.Increment(ref count) == 1)
+            {
+                return Task.FromException(expectedException);
+            }
+            nextSample.TrySetResult();
+            return Task.CompletedTask;
+        }, exception => reportedException.TrySetResult(exception));
+
+        listener.EnableReading();
+        var readerTask = listener.OnReadResultAsync(cts.Token).AsTask();
+        listener.EventCreatedHandler();
+        listener.EventCreatedHandler();
+
+        Assert.Same(expectedException, await reportedException.Task.WaitAsync(TestTimeout));
+        await nextSample.Task.WaitAsync(TestTimeout);
+        cts.Cancel();
+        await readerTask;
+        Assert.Equal(2, count);
+    }
+
     private sealed class RecordingProfiler : IProfiler
     {
         public string Name => nameof(RecordingProfiler);
@@ -166,14 +226,18 @@ public class ProfilerLifecycleTest
         }
     }
 
-    private sealed class TestableContentionEventListener(Func<ContentionEventStatistics, Task> onEventEmit)
-        : ContentionEventListener(onEventEmit, exception => throw exception)
+    private sealed class TestableContentionEventListener(
+        Func<ContentionEventStatistics, Task> onEventEmit,
+        Action<Exception>? onEventError = null)
+        : ContentionEventListener(onEventEmit, onEventError ?? (exception => throw exception))
     {
         public void EnableReading() => Enabled = true;
     }
 
-    private sealed class TestableThreadInfoTimerListener(Func<ThreadInfoStatistics, Task> onEventEmit)
-        : ThreadInfoTimerListener(onEventEmit, exception => throw exception, TimeSpan.FromDays(1), TimeSpan.FromDays(1))
+    private sealed class TestableThreadInfoTimerListener(
+        Func<ThreadInfoStatistics, Task> onEventEmit,
+        Action<Exception>? onEventError = null)
+        : ThreadInfoTimerListener(onEventEmit, onEventError ?? (exception => throw exception), TimeSpan.FromDays(1), TimeSpan.FromDays(1))
     {
         public void EnableReading() => Enabled = true;
     }

--- a/tests/ClrProfiler.UnitTest/ProfilerLifecycleTest.cs
+++ b/tests/ClrProfiler.UnitTest/ProfilerLifecycleTest.cs
@@ -1,0 +1,180 @@
+using ClrProfiler.EventListeners;
+using ClrProfiler.Statistics;
+using ClrProfiler.TimerListeners;
+
+namespace ClrProfiler.UnitTest;
+
+[Collection(nameof(TestCollectionDefinition))]
+public class ProfilerLifecycleTest
+{
+    private static readonly TimeSpan TestTimeout = TimeSpan.FromSeconds(5);
+
+    [Fact]
+    public void TrackerLifecycleTransitionsAreIdempotent()
+    {
+        var originalOptions = ProfilerTracker.Options;
+        using var firstCts = new CancellationTokenSource();
+        using var secondCts = new CancellationTokenSource();
+        var profiler = new RecordingProfiler();
+        var tracker = new ProfilerTracker([profiler]);
+
+        try
+        {
+            ProfilerTracker.Options = new ProfilerTrackerOptions { CancellationTokenSource = firstCts };
+
+            tracker.Start();
+            tracker.Start();
+            Assert.Equal(1, profiler.StartCount);
+            Assert.Equal(1, profiler.ReadCount);
+
+            tracker.Stop();
+            tracker.Stop();
+            Assert.Equal(1, profiler.StopCount);
+
+            tracker.Restart();
+            tracker.Restart();
+            Assert.Equal(1, profiler.RestartCount);
+            Assert.Equal(1, profiler.ReadCount);
+
+            tracker.Stop();
+            tracker.Start();
+            Assert.Equal(2, profiler.RestartCount);
+            Assert.Equal(1, profiler.ReadCount);
+
+            tracker.Cancel();
+            tracker.Cancel();
+            Assert.Equal(3, profiler.StopCount);
+            Assert.True(firstCts.IsCancellationRequested);
+
+            Assert.True(tracker.Reset(secondCts));
+            tracker.Start();
+            Assert.Equal(2, profiler.StartCount);
+            Assert.Equal(2, profiler.ReadCount);
+        }
+        finally
+        {
+            tracker.Cancel();
+            ProfilerTracker.Options = originalOptions;
+        }
+    }
+
+    [Fact]
+    public async Task EventReaderContinuesAfterStopAndRestart()
+    {
+        using var cts = new CancellationTokenSource(TestTimeout);
+        var firstEvent = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var secondEvent = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var count = 0;
+        using var listener = new TestableContentionEventListener(_ =>
+        {
+            if (Interlocked.Increment(ref count) == 1)
+            {
+                firstEvent.TrySetResult();
+            }
+            else
+            {
+                secondEvent.TrySetResult();
+            }
+            return Task.CompletedTask;
+        });
+
+        listener.EnableReading();
+        var readerTask = listener.OnReadResultAsync(cts.Token).AsTask();
+        listener.ProcessEvent("ContentionStop_V1", DateTime.UtcNow, [0U, 0U, 1.0]);
+        await firstEvent.Task.WaitAsync(TestTimeout);
+
+        listener.Stop();
+        listener.Restart();
+        listener.ProcessEvent("ContentionStop_V1", DateTime.UtcNow, [1U, 0U, 2.0]);
+        await secondEvent.Task.WaitAsync(TestTimeout);
+
+        cts.Cancel();
+        await readerTask;
+        Assert.Equal(2, count);
+    }
+
+    [Fact]
+    public async Task TimerReaderContinuesAfterStopAndRestart()
+    {
+        using var cts = new CancellationTokenSource(TestTimeout);
+        var firstSample = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var secondSample = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var count = 0;
+        using var listener = new TestableThreadInfoTimerListener(_ =>
+        {
+            if (Interlocked.Increment(ref count) == 1)
+            {
+                firstSample.TrySetResult();
+            }
+            else
+            {
+                secondSample.TrySetResult();
+            }
+            return Task.CompletedTask;
+        });
+
+        listener.EnableReading();
+        var readerTask = listener.OnReadResultAsync(cts.Token).AsTask();
+        listener.EventCreatedHandler();
+        await firstSample.Task.WaitAsync(TestTimeout);
+
+        listener.Stop();
+        listener.Restart();
+        listener.EventCreatedHandler();
+        await secondSample.Task.WaitAsync(TestTimeout);
+
+        cts.Cancel();
+        await readerTask;
+        Assert.Equal(2, count);
+    }
+
+    private sealed class RecordingProfiler : IProfiler
+    {
+        public string Name => nameof(RecordingProfiler);
+        public bool Enabled { get; private set; }
+        public int StartCount { get; private set; }
+        public int RestartCount { get; private set; }
+        public int StopCount { get; private set; }
+        public int ReadCount { get; private set; }
+
+        public void Start()
+        {
+            Enabled = true;
+            StartCount++;
+        }
+
+        public void Restart()
+        {
+            Enabled = true;
+            RestartCount++;
+        }
+
+        public void Stop()
+        {
+            Enabled = false;
+            StopCount++;
+        }
+
+        public Task ReadResultAsync(CancellationToken cancellationToken)
+        {
+            ReadCount++;
+            return Task.CompletedTask;
+        }
+
+        public void Dispose()
+        {
+        }
+    }
+
+    private sealed class TestableContentionEventListener(Func<ContentionEventStatistics, Task> onEventEmit)
+        : ContentionEventListener(onEventEmit, exception => throw exception)
+    {
+        public void EnableReading() => Enabled = true;
+    }
+
+    private sealed class TestableThreadInfoTimerListener(Func<ThreadInfoStatistics, Task> onEventEmit)
+        : ThreadInfoTimerListener(onEventEmit, exception => throw exception, TimeSpan.FromDays(1), TimeSpan.FromDays(1))
+    {
+        public void EnableReading() => Enabled = true;
+    }
+}

--- a/tests/ClrProfiler.UnitTest/TimerListenerDataIntegrityTest.cs
+++ b/tests/ClrProfiler.UnitTest/TimerListenerDataIntegrityTest.cs
@@ -14,13 +14,14 @@ public class TimerListenerDataIntegrityTest
     public async Task GCInfoTimerListenerPreservesEverySampleAtChannelCapacity()
     {
         var actual = new List<GCInfoStatistics>(ChannelCapacity);
+        using var cts = new CancellationTokenSource(TestTimeout);
         TestableGCInfoTimerListener? listener = null;
         listener = new TestableGCInfoTimerListener(value =>
         {
             actual.Add(value);
             if (actual.Count == ChannelCapacity)
             {
-                listener!.DisableReading();
+                cts.Cancel();
             }
             return Task.CompletedTask;
         });
@@ -32,7 +33,6 @@ public class TimerListenerDataIntegrityTest
             }
 
             listener.EnableReading();
-            using var cts = new CancellationTokenSource(TestTimeout);
             await listener.OnReadResultAsync(cts.Token);
         }
 
@@ -52,13 +52,14 @@ public class TimerListenerDataIntegrityTest
     public async Task ProcessInfoTimerListenerPreservesEverySampleAtChannelCapacity()
     {
         var actual = new List<ProcessInfoStatistics>(ChannelCapacity);
+        using var cts = new CancellationTokenSource(TestTimeout);
         TestableProcessInfoTimerListener? listener = null;
         listener = new TestableProcessInfoTimerListener(value =>
         {
             actual.Add(value);
             if (actual.Count == ChannelCapacity)
             {
-                listener!.DisableReading();
+                cts.Cancel();
             }
             return Task.CompletedTask;
         });
@@ -70,7 +71,6 @@ public class TimerListenerDataIntegrityTest
             }
 
             listener.EnableReading();
-            using var cts = new CancellationTokenSource(TestTimeout);
             await listener.OnReadResultAsync(cts.Token);
         }
 
@@ -88,13 +88,14 @@ public class TimerListenerDataIntegrityTest
     public async Task ThreadInfoTimerListenerPreservesEverySampleAtChannelCapacity()
     {
         var actual = new List<ThreadInfoStatistics>(ChannelCapacity);
+        using var cts = new CancellationTokenSource(TestTimeout);
         TestableThreadInfoTimerListener? listener = null;
         listener = new TestableThreadInfoTimerListener(value =>
         {
             actual.Add(value);
             if (actual.Count == ChannelCapacity)
             {
-                listener!.DisableReading();
+                cts.Cancel();
             }
             return Task.CompletedTask;
         });
@@ -106,7 +107,6 @@ public class TimerListenerDataIntegrityTest
             }
 
             listener.EnableReading();
-            using var cts = new CancellationTokenSource(TestTimeout);
             await listener.OnReadResultAsync(cts.Token);
         }
 


### PR DESCRIPTION
## Summary

- Fix `Start`/`Stop`/`Restart` lifecycle handling with explicit state transitions.
- Keep channel readers alive across stop/restart and terminate them only on cancellation.
- Prevent duplicate readers and repeated lifecycle operations.
- Add `ClrTracker.RestartTracker()`.
- Add regression tests for lifecycle transitions and data delivery after restart.

## Intent

Ensure profiling can be safely stopped and resumed without losing channel consumers or creating duplicate readers.