### PR TITLE
feat: Match GC Start/End by GC index

### DIFF
--- a/src/ClrProfiler/EventListeners/GCEventListener.cs
+++ b/src/ClrProfiler/EventListeners/GCEventListener.cs
@@ -95,11 +95,11 @@ public class GCEventListener : ProfileEventListenerBase, IChannelReader
                     ReadRequiredUInt32(payload, 2),
                     timeStamp.Ticks);
 
-                var storeResult = StoreGCStartState(startState);
+                var storeResult = StoreGCStartState(startState, out var evictedIndex);
                 if (storeResult != GCStartStateStoreResult.Stored)
                 {
                     throw new InvalidOperationException(storeResult == GCStartStateStoreResult.ReplacedOldest
-                        ? $"GC correlation capacity exceeded. Replaced the oldest start with index {gcIndex}."
+                        ? $"GC correlation capacity exceeded. Evicted start with index {evictedIndex} to store start with index {gcIndex}."
                         : $"GC correlation state was busy. Dropped start with index {gcIndex}.");
                 }
             }
@@ -152,8 +152,9 @@ public class GCEventListener : ProfileEventListenerBase, IChannelReader
         }
     }
 
-    private GCStartStateStoreResult StoreGCStartState(in GCStartState startState)
+    private GCStartStateStoreResult StoreGCStartState(in GCStartState startState, out uint evictedIndex)
     {
+        evictedIndex = 0;
         var firstSlot = (int)(startState.Index % GCStartStateCapacity);
         var owner = GetCorrelationOwner(startState.Index);
         for (var offset = 0; offset < GCStartStateCapacity; offset++)
@@ -197,6 +198,7 @@ public class GCEventListener : ProfileEventListenerBase, IChannelReader
             ref var oldestSlot = ref _gcStartStates[oldestSlotIndex];
             if (Interlocked.CompareExchange(ref oldestSlot.Owner, -owner, oldestOwner) == oldestOwner)
             {
+                evictedIndex = (uint)(oldestOwner - 1);
                 WriteGCStartState(ref oldestSlot, startState, owner);
                 return GCStartStateStoreResult.ReplacedOldest;
             }

--- a/src/ClrProfiler/EventListeners/GCEventListener.cs
+++ b/src/ClrProfiler/EventListeners/GCEventListener.cs
@@ -10,12 +10,17 @@ namespace ClrProfiler.EventListeners;
 /// </summary>
 public class GCEventListener : ProfileEventListenerBase, IChannelReader
 {
+    // A background GC can overlap a foreground GC, so GC start state must be
+    // correlated by the GC index carried by both GCStart and GCEnd. GC indices
+    // are sequential and the runtime cannot have this many collections active
+    // concurrently, making a fixed array sufficient without per-event allocation.
+    private const int GCStartStateCapacity = 64;
+
     private readonly Channel<GCEventStatistics> _channel;
     private readonly Func<GCEventStatistics, Task> _onEventEmit;
     private readonly Action<Exception> _onEventError;
-    long timeGCStart = 0;
-    uint reason = 0;
-    uint type = 0;
+    private readonly GCStartState[] _gcStartStates = new GCStartState[GCStartStateCapacity];
+    private readonly object _gcStartStatesLock = new();
 
     // suspend
     long suspendTimeGCStart = 0;
@@ -84,17 +89,41 @@ public class GCEventListener : ProfileEventListenerBase, IChannelReader
             // NOTE: HeapStat will retrieve in GCInfoTimerListener
             if (eventName.StartsWith("GCStart_", StringComparison.OrdinalIgnoreCase)) // GCStart_V1 / V2 ...
             {
-                timeGCStart = timeStamp.Ticks;
-                reason = uint.Parse(payload?[2]?.ToString() ?? "0");
-                type = uint.Parse(payload?[3]?.ToString() ?? "0");
+                var gcIndex = ReadUInt32(payload, 0);
+                var startState = new GCStartState(
+                    gcIndex,
+                    ReadUInt32(payload, 3),
+                    ReadUInt32(payload, 2),
+                    timeStamp.Ticks);
+
+                lock (_gcStartStatesLock)
+                {
+                    _gcStartStates[GetGCStartStateSlot(gcIndex)] = startState;
+                }
             }
             else if (eventName.StartsWith("GCEnd_", StringComparison.OrdinalIgnoreCase)) // GCEnd_V1 / V2 ...
             {
                 long timeGCEnd = timeStamp.Ticks;
-                var gcIndex = uint.Parse(payload?[0]?.ToString() ?? "0");
-                var generation = uint.Parse(payload?[1]?.ToString() ?? "0");
-                var duration = (double)(timeGCEnd - timeGCStart) / 10.0 / 1000.0;
-                var stat = new GCStartEndStatistics(gcIndex, type, generation, reason, duration, timeGCStart, timeGCEnd);
+                var gcIndex = ReadUInt32(payload, 0);
+                var generation = ReadUInt32(payload, 1);
+                GCStartState startState;
+
+                lock (_gcStartStatesLock)
+                {
+                    var slot = GetGCStartStateSlot(gcIndex);
+                    startState = _gcStartStates[slot];
+                    if (!startState.Active || startState.Index != gcIndex)
+                    {
+                        // The listener may be enabled in the middle of a GC and
+                        // observe its end without having observed its start.
+                        return;
+                    }
+
+                    _gcStartStates[slot] = default;
+                }
+
+                var duration = (double)(timeGCEnd - startState.StartTime) / 10.0 / 1000.0;
+                var stat = new GCStartEndStatistics(gcIndex, startState.Type, generation, startState.Reason, duration, startState.StartTime, timeGCEnd);
 
                 // write to channel
                 _channel.Writer.TryWrite(new GCEventStatistics(GCEventType.GCStartEnd, stat, new()));
@@ -119,6 +148,39 @@ public class GCEventListener : ProfileEventListenerBase, IChannelReader
         {
             _onEventError?.Invoke(ex);
         }
+    }
+
+    private static int GetGCStartStateSlot(uint gcIndex) => (int)(gcIndex % GCStartStateCapacity);
+
+    private static uint ReadUInt32(IReadOnlyList<object?>? payload, int index)
+    {
+        if (payload is null || (uint)index >= (uint)payload.Count)
+        {
+            return 0;
+        }
+
+        return payload[index] switch
+        {
+            uint value => value,
+            int value => checked((uint)value),
+            ushort value => value,
+            short value => checked((uint)value),
+            byte value => value,
+            sbyte value => checked((uint)value),
+            ulong value => checked((uint)value),
+            long value => checked((uint)value),
+            null => 0,
+            _ => Convert.ToUInt32(payload[index], System.Globalization.CultureInfo.InvariantCulture),
+        };
+    }
+
+    private readonly struct GCStartState(uint index, uint type, uint reason, long startTime)
+    {
+        public readonly uint Index = index;
+        public readonly uint Type = type;
+        public readonly uint Reason = reason;
+        public readonly long StartTime = startTime;
+        public readonly bool Active = true;
     }
 
     public async ValueTask OnReadResultAsync(CancellationToken cancellationToken = default)

--- a/src/ClrProfiler/EventListeners/GCEventListener.cs
+++ b/src/ClrProfiler/EventListeners/GCEventListener.cs
@@ -10,22 +10,21 @@ namespace ClrProfiler.EventListeners;
 /// </summary>
 public class GCEventListener : ProfileEventListenerBase, IChannelReader
 {
-    // A background GC can overlap a foreground GC, so GC start state must be
-    // correlated by the GC index carried by both GCStart and GCEnd. GC indices
-    // are sequential and the runtime cannot have this many collections active
-    // concurrently, making a fixed array sufficient without per-event allocation.
+    // A background GC can overlap foreground GCs, so correlate by GC index.
+    // Linear probing keeps the state bounded and allocation-free per event while
+    // allowing indices separated by the table capacity to remain active together.
     private const int GCStartStateCapacity = 64;
 
     private readonly Channel<GCEventStatistics> _channel;
     private readonly Func<GCEventStatistics, Task> _onEventEmit;
     private readonly Action<Exception> _onEventError;
-    private readonly GCStartState[] _gcStartStates = new GCStartState[GCStartStateCapacity];
-    private readonly object _gcStartStatesLock = new();
+    private readonly GCStartStateSlot[] _gcStartStates = new GCStartStateSlot[GCStartStateCapacity];
 
     // suspend
-    long suspendTimeGCStart = 0;
-    uint suspendReason = 0;
-    uint suspendCount = 0;
+    private long _suspendOwner;
+    private long _suspendTimeGCStart;
+    private uint _suspendReason;
+    private uint _suspendCount;
 
     public GCEventListener(Func<GCEventStatistics, Task> onEventEmit, Action<Exception> onEventError) : base("Microsoft-Windows-DotNETRuntime", EventLevel.Informational, ClrRuntimeEventKeywords.GC)
     {
@@ -34,7 +33,7 @@ public class GCEventListener : ProfileEventListenerBase, IChannelReader
         var channelOption = new BoundedChannelOptions(50)
         {
             SingleReader = true,
-            SingleWriter = true,
+            SingleWriter = false,
             FullMode = BoundedChannelFullMode.DropOldest,
         };
         _channel = Channel.CreateBounded<GCEventStatistics>(channelOption);
@@ -89,37 +88,31 @@ public class GCEventListener : ProfileEventListenerBase, IChannelReader
             // NOTE: HeapStat will retrieve in GCInfoTimerListener
             if (eventName.StartsWith("GCStart_", StringComparison.OrdinalIgnoreCase)) // GCStart_V1 / V2 ...
             {
-                var gcIndex = ReadUInt32(payload, 0);
+                var gcIndex = ReadRequiredUInt32(payload, 0);
                 var startState = new GCStartState(
                     gcIndex,
-                    ReadUInt32(payload, 3),
-                    ReadUInt32(payload, 2),
+                    ReadRequiredUInt32(payload, 3),
+                    ReadRequiredUInt32(payload, 2),
                     timeStamp.Ticks);
 
-                lock (_gcStartStatesLock)
+                var storeResult = StoreGCStartState(startState);
+                if (storeResult != GCStartStateStoreResult.Stored)
                 {
-                    _gcStartStates[GetGCStartStateSlot(gcIndex)] = startState;
+                    throw new InvalidOperationException(storeResult == GCStartStateStoreResult.ReplacedOldest
+                        ? $"GC correlation capacity exceeded. Replaced the oldest start with index {gcIndex}."
+                        : $"GC correlation state was busy. Dropped start with index {gcIndex}.");
                 }
             }
             else if (eventName.StartsWith("GCEnd_", StringComparison.OrdinalIgnoreCase)) // GCEnd_V1 / V2 ...
             {
                 long timeGCEnd = timeStamp.Ticks;
-                var gcIndex = ReadUInt32(payload, 0);
-                var generation = ReadUInt32(payload, 1);
-                GCStartState startState;
-
-                lock (_gcStartStatesLock)
+                var gcIndex = ReadRequiredUInt32(payload, 0);
+                var generation = ReadRequiredUInt32(payload, 1);
+                if (!TryTakeGCStartState(gcIndex, out var startState))
                 {
-                    var slot = GetGCStartStateSlot(gcIndex);
-                    startState = _gcStartStates[slot];
-                    if (!startState.Active || startState.Index != gcIndex)
-                    {
-                        // The listener may be enabled in the middle of a GC and
-                        // observe its end without having observed its start.
-                        return;
-                    }
-
-                    _gcStartStates[slot] = default;
+                    // The listener may be enabled in the middle of a GC and
+                    // observe its end without having observed its start.
+                    return;
                 }
 
                 var duration = (double)(timeGCEnd - startState.StartTime) / 10.0 / 1000.0;
@@ -130,14 +123,23 @@ public class GCEventListener : ProfileEventListenerBase, IChannelReader
             }
             else if (eventName.StartsWith("GCSuspendEEBegin", StringComparison.OrdinalIgnoreCase))
             {
-                suspendTimeGCStart = timeStamp.Ticks;
-                suspendReason = uint.Parse(payload?[0]?.ToString() ?? "0");
-                suspendCount = uint.Parse(payload?[1]?.ToString() ?? "0");
+                var reason = ReadRequiredUInt32(payload, 0);
+                var count = ReadRequiredUInt32(payload, 1);
+                var replacedActiveSuspend = !TryBeginSuspend(timeStamp.Ticks, reason, count);
+                if (replacedActiveSuspend)
+                {
+                    throw new InvalidOperationException("A new GC suspend start replaced an unmatched active suspend start.");
+                }
             }
             else if (eventName.StartsWith("GCRestartEEEnd", StringComparison.OrdinalIgnoreCase))
             {
                 var suspendEnd = timeStamp.Ticks;
-                var duration = (double)(suspendEnd - suspendTimeGCStart) / 10.0 / 1000.0;
+                if (!TryEndSuspend(out var suspendStart, out var suspendReason, out var suspendCount))
+                {
+                    return;
+                }
+
+                var duration = (double)(suspendEnd - suspendStart) / 10.0 / 1000.0;
                 var stat = new GCSuspendStatistics(duration, suspendReason, suspendCount);
 
                 // write to channel
@@ -150,13 +152,140 @@ public class GCEventListener : ProfileEventListenerBase, IChannelReader
         }
     }
 
-    private static int GetGCStartStateSlot(uint gcIndex) => (int)(gcIndex % GCStartStateCapacity);
-
-    private static uint ReadUInt32(IReadOnlyList<object?>? payload, int index)
+    private GCStartStateStoreResult StoreGCStartState(in GCStartState startState)
     {
-        if (payload is null || (uint)index >= (uint)payload.Count)
+        var firstSlot = (int)(startState.Index % GCStartStateCapacity);
+        var owner = GetCorrelationOwner(startState.Index);
+        for (var offset = 0; offset < GCStartStateCapacity; offset++)
         {
-            return 0;
+            ref var slot = ref _gcStartStates[(firstSlot + offset) % GCStartStateCapacity];
+            var observedOwner = Volatile.Read(ref slot.Owner);
+            if (observedOwner == owner)
+            {
+                if (Interlocked.CompareExchange(ref slot.Owner, -owner, owner) == owner)
+                {
+                    WriteGCStartState(ref slot, startState, owner);
+                    return GCStartStateStoreResult.Stored;
+                }
+                continue;
+            }
+
+            if (observedOwner == 0 && Interlocked.CompareExchange(ref slot.Owner, -owner, 0) == 0)
+            {
+                WriteGCStartState(ref slot, startState, owner);
+                return GCStartStateStoreResult.Stored;
+            }
+        }
+
+        var oldestSlotIndex = -1;
+        var oldestStartTime = long.MaxValue;
+        var oldestOwner = 0L;
+        for (var i = 0; i < GCStartStateCapacity; i++)
+        {
+            ref var slot = ref _gcStartStates[i];
+            var observedOwner = Volatile.Read(ref slot.Owner);
+            if (observedOwner > 0 && slot.StartTime < oldestStartTime)
+            {
+                oldestStartTime = slot.StartTime;
+                oldestSlotIndex = i;
+                oldestOwner = observedOwner;
+            }
+        }
+
+        if (oldestSlotIndex >= 0)
+        {
+            ref var oldestSlot = ref _gcStartStates[oldestSlotIndex];
+            if (Interlocked.CompareExchange(ref oldestSlot.Owner, -owner, oldestOwner) == oldestOwner)
+            {
+                WriteGCStartState(ref oldestSlot, startState, owner);
+                return GCStartStateStoreResult.ReplacedOldest;
+            }
+        }
+
+        return GCStartStateStoreResult.Dropped;
+    }
+
+    private bool TryTakeGCStartState(uint gcIndex, out GCStartState startState)
+    {
+        var firstSlot = (int)(gcIndex % GCStartStateCapacity);
+        var owner = GetCorrelationOwner(gcIndex);
+        for (var offset = 0; offset < GCStartStateCapacity; offset++)
+        {
+            ref var slot = ref _gcStartStates[(firstSlot + offset) % GCStartStateCapacity];
+            if (Volatile.Read(ref slot.Owner) != owner)
+            {
+                continue;
+            }
+
+            if (Interlocked.CompareExchange(ref slot.Owner, -owner, owner) != owner)
+            {
+                continue;
+            }
+
+            startState = new GCStartState(slot.Index, slot.Type, slot.Reason, slot.StartTime);
+            Volatile.Write(ref slot.Owner, 0);
+            return true;
+        }
+
+        startState = default;
+        return false;
+    }
+
+    private static void WriteGCStartState(ref GCStartStateSlot slot, in GCStartState startState, long owner)
+    {
+        slot.Index = startState.Index;
+        slot.Type = startState.Type;
+        slot.Reason = startState.Reason;
+        slot.StartTime = startState.StartTime;
+        Volatile.Write(ref slot.Owner, owner);
+    }
+
+    private static long GetCorrelationOwner(uint index) => (long)index + 1;
+
+    private bool TryBeginSuspend(long startTime, uint reason, uint count)
+    {
+        var owner = GetCorrelationOwner(count);
+        var previousOwner = Interlocked.CompareExchange(ref _suspendOwner, -owner, 0);
+        var replacedActive = false;
+        if (previousOwner != 0)
+        {
+            if (previousOwner < 0 || Interlocked.CompareExchange(ref _suspendOwner, -owner, previousOwner) != previousOwner)
+            {
+                throw new InvalidOperationException("GC suspend correlation state was busy. Dropped the suspend start.");
+            }
+            replacedActive = true;
+        }
+
+        _suspendTimeGCStart = startTime;
+        _suspendReason = reason;
+        _suspendCount = count;
+        Volatile.Write(ref _suspendOwner, owner);
+        return !replacedActive;
+    }
+
+    private bool TryEndSuspend(out long startTime, out uint reason, out uint count)
+    {
+        var owner = Volatile.Read(ref _suspendOwner);
+        if (owner <= 0 || Interlocked.CompareExchange(ref _suspendOwner, -owner, owner) != owner)
+        {
+            startTime = 0;
+            reason = 0;
+            count = 0;
+            return false;
+        }
+
+        startTime = _suspendTimeGCStart;
+        reason = _suspendReason;
+        count = _suspendCount;
+        Volatile.Write(ref _suspendOwner, 0);
+        return true;
+    }
+
+    private static uint ReadRequiredUInt32(IReadOnlyList<object?>? payload, int index)
+    {
+        if (payload is null || (uint)index >= (uint)payload.Count || payload[index] is null)
+        {
+            throw new InvalidDataException($"Required GC payload at index {index} is missing.");
         }
 
         return payload[index] switch
@@ -169,7 +298,6 @@ public class GCEventListener : ProfileEventListenerBase, IChannelReader
             sbyte value => checked((uint)value),
             ulong value => checked((uint)value),
             long value => checked((uint)value),
-            null => 0,
             _ => Convert.ToUInt32(payload[index], System.Globalization.CultureInfo.InvariantCulture),
         };
     }
@@ -180,7 +308,22 @@ public class GCEventListener : ProfileEventListenerBase, IChannelReader
         public readonly uint Type = type;
         public readonly uint Reason = reason;
         public readonly long StartTime = startTime;
-        public readonly bool Active = true;
+    }
+
+    private struct GCStartStateSlot
+    {
+        public long Owner;
+        public uint Index;
+        public uint Type;
+        public uint Reason;
+        public long StartTime;
+    }
+
+    private enum GCStartStateStoreResult
+    {
+        Stored,
+        ReplacedOldest,
+        Dropped,
     }
 
     public async ValueTask OnReadResultAsync(CancellationToken cancellationToken = default)

--- a/tests/ClrProfiler.UnitTest/EventListenerDataIntegrityTest.cs
+++ b/tests/ClrProfiler.UnitTest/EventListenerDataIntegrityTest.cs
@@ -382,7 +382,8 @@ public class EventListenerDataIntegrityTest
         Assert.Equal((uint)correlationCapacity, result.Index);
         Assert.Equal(1U, result.Reason);
         Assert.Single(errors);
-        Assert.IsType<InvalidOperationException>(errors[0]);
+        var error = Assert.IsType<InvalidOperationException>(errors[0]);
+        Assert.Equal("GC correlation capacity exceeded. Evicted start with index 0 to store start with index 64.", error.Message);
     }
 
     [Fact]

--- a/tests/ClrProfiler.UnitTest/EventListenerDataIntegrityTest.cs
+++ b/tests/ClrProfiler.UnitTest/EventListenerDataIntegrityTest.cs
@@ -64,6 +64,49 @@ public class EventListenerDataIntegrityTest
     }
 
     [Fact]
+    public async Task GCEventListenerCorrelatesOverlappingCollectionsByIndex()
+    {
+        var actual = new List<GCEventStatistics>(2);
+        using var cts = new CancellationTokenSource(TestTimeout);
+        using var listener = new TestableGCEventListener(value =>
+        {
+            actual.Add(value);
+            if (actual.Count == 2)
+            {
+                cts.Cancel();
+            }
+            return Task.CompletedTask;
+        });
+
+        var origin = new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+        listener.ProcessEvent("GCStart_V2", origin, [100U, 2U, 4U, 1U]);
+        listener.ProcessEvent("GCStart_V2", origin.AddTicks(10_000), [101U, 0U, 0U, 0U]);
+        listener.ProcessEvent("GCEnd_V1", origin.AddTicks(15_000), [101U, 0U]);
+        listener.ProcessEvent("GCEnd_V1", origin.AddTicks(50_000), [100U, 2U]);
+
+        listener.EnableReading();
+        await listener.OnReadResultAsync(cts.Token);
+
+        Assert.Equal(2, actual.Count);
+
+        var foreground = actual[0].GCStartEndStatistics;
+        Assert.Equal(101U, foreground.Index);
+        Assert.Equal(0U, foreground.Type);
+        Assert.Equal(0U, foreground.Generation);
+        Assert.Equal(0U, foreground.Reason);
+        Assert.Equal(origin.AddTicks(10_000).Ticks, foreground.GCStartTime);
+        Assert.Equal(0.5, foreground.DurationMillsec);
+
+        var background = actual[1].GCStartEndStatistics;
+        Assert.Equal(100U, background.Index);
+        Assert.Equal(1U, background.Type);
+        Assert.Equal(2U, background.Generation);
+        Assert.Equal(4U, background.Reason);
+        Assert.Equal(origin.Ticks, background.GCStartTime);
+        Assert.Equal(5.0, background.DurationMillsec);
+    }
+
+    [Fact]
     public async Task ContentionEventListenerPreservesEveryEventAtChannelCapacity()
     {
         var actual = new List<ContentionEventStatistics>(ChannelCapacity);

--- a/tests/ClrProfiler.UnitTest/EventListenerDataIntegrityTest.cs
+++ b/tests/ClrProfiler.UnitTest/EventListenerDataIntegrityTest.cs
@@ -107,6 +107,354 @@ public class EventListenerDataIntegrityTest
     }
 
     [Fact]
+    public async Task GCEventListenerDoesNotLoseLongRunningBackgroundGCOnIndexCollision()
+    {
+        var actual = new List<GCEventStatistics>(2);
+        var completed = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        using var cts = new CancellationTokenSource(TestTimeout);
+        using var listener = new TestableGCEventListener(value =>
+        {
+            actual.Add(value);
+            if (actual.Count == 2)
+            {
+                completed.TrySetResult();
+            }
+            return Task.CompletedTask;
+        });
+
+        var origin = new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+        listener.EnableReading();
+        var readerTask = listener.OnReadResultAsync(cts.Token).AsTask();
+        try
+        {
+            listener.ProcessEvent("GCStart_V2", origin, [0U, 2U, 4U, 1U]);
+            listener.ProcessEvent("GCStart_V2", origin.AddTicks(10_000), [64U, 0U, 0U, 0U]);
+            listener.ProcessEvent("GCEnd_V1", origin.AddTicks(15_000), [64U, 0U]);
+            listener.ProcessEvent("GCEnd_V1", origin.AddTicks(50_000), [0U, 2U]);
+
+            await completed.Task.WaitAsync(TestTimeout, TestContext.Current.CancellationToken);
+        }
+        finally
+        {
+            await cts.CancelAsync();
+            await readerTask;
+        }
+
+        Assert.Equal([64U, 0U], actual.Select(x => x.GCStartEndStatistics.Index));
+        Assert.Equal(0.5, actual[0].GCStartEndStatistics.DurationMillsec);
+        Assert.Equal(5.0, actual[1].GCStartEndStatistics.DurationMillsec);
+    }
+
+    [Fact]
+    public async Task GCEventListenerCorrelatesCollidingIndicesFromConcurrentWriters()
+    {
+        var actual = new List<GCEventStatistics>(2);
+        var completed = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        using var cts = new CancellationTokenSource(TestTimeout);
+        using var listener = new TestableGCEventListener(value =>
+        {
+            actual.Add(value);
+            if (actual.Count == 2)
+            {
+                completed.TrySetResult();
+            }
+            return Task.CompletedTask;
+        });
+        using var startBarrier = new Barrier(2);
+        using var endBarrier = new Barrier(2);
+
+        var origin = new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+        listener.EnableReading();
+        var readerTask = listener.OnReadResultAsync(cts.Token).AsTask();
+        try
+        {
+            await Task.WhenAll(
+                Task.Run(() =>
+                {
+                    startBarrier.SignalAndWait(TestContext.Current.CancellationToken);
+                    listener.ProcessEvent("GCStart_V2", origin, [0U, 2U, 4U, 1U]);
+                }, TestContext.Current.CancellationToken),
+                Task.Run(() =>
+                {
+                    startBarrier.SignalAndWait(TestContext.Current.CancellationToken);
+                    listener.ProcessEvent("GCStart_V2", origin.AddTicks(10_000), [64U, 0U, 0U, 0U]);
+                }, TestContext.Current.CancellationToken));
+
+            await Task.WhenAll(
+                Task.Run(() =>
+                {
+                    endBarrier.SignalAndWait(TestContext.Current.CancellationToken);
+                    listener.ProcessEvent("GCEnd_V1", origin.AddTicks(50_000), [0U, 2U]);
+                }, TestContext.Current.CancellationToken),
+                Task.Run(() =>
+                {
+                    endBarrier.SignalAndWait(TestContext.Current.CancellationToken);
+                    listener.ProcessEvent("GCEnd_V1", origin.AddTicks(15_000), [64U, 0U]);
+                }, TestContext.Current.CancellationToken));
+
+            await completed.Task.WaitAsync(TestTimeout, TestContext.Current.CancellationToken);
+        }
+        finally
+        {
+            await cts.CancelAsync();
+            await readerTask;
+        }
+
+        Assert.Equal([0U, 64U], actual.Select(x => x.GCStartEndStatistics.Index).Order());
+    }
+
+    [Fact]
+    public async Task GCEventListenerMalformedEndDoesNotConsumeValidStart()
+    {
+        var actual = new List<GCEventStatistics>(1);
+        var errors = new List<Exception>(1);
+        var completed = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        using var cts = new CancellationTokenSource(TestTimeout);
+        using var listener = new TestableGCEventListener(value =>
+        {
+            actual.Add(value);
+            completed.TrySetResult();
+            return Task.CompletedTask;
+        }, errors.Add);
+
+        var origin = new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+        listener.EnableReading();
+        var readerTask = listener.OnReadResultAsync(cts.Token).AsTask();
+        try
+        {
+            listener.ProcessEvent("GCStart_V2", origin, [0U, 2U, 4U, 1U]);
+            listener.ProcessEvent("GCEnd_V1", origin.AddTicks(1_000), []);
+            listener.ProcessEvent("GCEnd_V1", origin.AddTicks(50_000), [0U, 2U]);
+
+            await completed.Task.WaitAsync(TestTimeout, TestContext.Current.CancellationToken);
+        }
+        finally
+        {
+            await cts.CancelAsync();
+            await readerTask;
+        }
+
+        var result = Assert.Single(actual).GCStartEndStatistics;
+        Assert.Equal(0U, result.Index);
+        Assert.Equal(origin.AddTicks(50_000).Ticks, result.GCEndTime);
+        Assert.Equal(5.0, result.DurationMillsec);
+        Assert.Single(errors);
+    }
+
+    [Fact]
+    public async Task GCEventListenerMalformedStartDoesNotReplaceValidStart()
+    {
+        var actual = new List<GCEventStatistics>(1);
+        var errors = new List<Exception>(1);
+        var completed = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        using var cts = new CancellationTokenSource(TestTimeout);
+        using var listener = new TestableGCEventListener(value =>
+        {
+            actual.Add(value);
+            completed.TrySetResult();
+            return Task.CompletedTask;
+        }, errors.Add);
+
+        var origin = new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+        listener.EnableReading();
+        var readerTask = listener.OnReadResultAsync(cts.Token).AsTask();
+        try
+        {
+            listener.ProcessEvent("GCStart_V2", origin, [0U, 2U, 4U, 1U]);
+            listener.ProcessEvent("GCStart_V2", origin.AddTicks(1_000), []);
+            listener.ProcessEvent("GCEnd_V1", origin.AddTicks(50_000), [0U, 2U]);
+
+            await completed.Task.WaitAsync(TestTimeout, TestContext.Current.CancellationToken);
+        }
+        finally
+        {
+            await cts.CancelAsync();
+            await readerTask;
+        }
+
+        var result = Assert.Single(actual).GCStartEndStatistics;
+        Assert.Equal(origin.Ticks, result.GCStartTime);
+        Assert.Equal(5.0, result.DurationMillsec);
+        Assert.Single(errors);
+    }
+
+    [Fact]
+    public async Task GCEventListenerAcceptsSupportedIntegerPayloadRepresentations()
+    {
+        var actual = new List<GCEventStatistics>(1);
+        var completed = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        using var cts = new CancellationTokenSource(TestTimeout);
+        using var listener = new TestableGCEventListener(value =>
+        {
+            actual.Add(value);
+            completed.TrySetResult();
+            return Task.CompletedTask;
+        });
+
+        var origin = new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+        listener.EnableReading();
+        var readerTask = listener.OnReadResultAsync(cts.Token).AsTask();
+        try
+        {
+            listener.ProcessEvent("GCStart_V2", origin, [1, (short)2, "4", (byte)1]);
+            listener.ProcessEvent("GCEnd_V1", origin.AddTicks(5_000), [1L, (ushort)2]);
+
+            await completed.Task.WaitAsync(TestTimeout, TestContext.Current.CancellationToken);
+        }
+        finally
+        {
+            await cts.CancelAsync();
+            await readerTask;
+        }
+
+        var result = Assert.Single(actual).GCStartEndStatistics;
+        Assert.Equal(1U, result.Index);
+        Assert.Equal(1U, result.Type);
+        Assert.Equal(2U, result.Generation);
+        Assert.Equal(4U, result.Reason);
+        Assert.Equal(0.5, result.DurationMillsec);
+    }
+
+    [Fact]
+    public void GCEventListenerNormalStartEndHotPathDoesNotAllocate()
+    {
+        using var listener = new TestableGCEventListener(_ => Task.CompletedTask);
+        object?[] startPayload = [0U, 2U, 4U, 1U];
+        object?[] endPayload = [0U, 2U];
+        var start = new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+        var end = start.AddTicks(5_000);
+
+        for (var i = 0; i < 100; i++)
+        {
+            listener.ProcessEvent("GCStart_V2", start, startPayload);
+            listener.ProcessEvent("GCEnd_V1", end, endPayload);
+        }
+
+        var before = GC.GetAllocatedBytesForCurrentThread();
+        for (var i = 0; i < 10_000; i++)
+        {
+            listener.ProcessEvent("GCStart_V2", start, startPayload);
+            listener.ProcessEvent("GCEnd_V1", end, endPayload);
+        }
+        var allocated = GC.GetAllocatedBytesForCurrentThread() - before;
+
+        Assert.Equal(0, allocated);
+    }
+
+    [Fact]
+    public async Task GCEventListenerEvictsOldestStaleStartAndReportsBoundedStateOverflow()
+    {
+        const int correlationCapacity = 64;
+        var actual = new List<GCEventStatistics>(1);
+        var errors = new List<Exception>(1);
+        var completed = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        using var cts = new CancellationTokenSource(TestTimeout);
+        using var listener = new TestableGCEventListener(value =>
+        {
+            actual.Add(value);
+            completed.TrySetResult();
+            return Task.CompletedTask;
+        }, errors.Add);
+
+        var origin = new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+        listener.EnableReading();
+        var readerTask = listener.OnReadResultAsync(cts.Token).AsTask();
+        try
+        {
+            for (var i = 0; i < correlationCapacity; i++)
+            {
+                listener.ProcessEvent("GCStart_V2", origin.AddTicks(i), [(uint)i, 0U, 0U, 0U]);
+            }
+
+            listener.ProcessEvent("GCStart_V2", origin.AddTicks(correlationCapacity), [(uint)correlationCapacity, 0U, 1U, 0U]);
+            listener.ProcessEvent("GCEnd_V1", origin.AddTicks(correlationCapacity + 5_000), [(uint)correlationCapacity, 0U]);
+            listener.ProcessEvent("GCEnd_V1", origin.AddTicks(correlationCapacity + 10_000), [0U, 0U]);
+
+            await completed.Task.WaitAsync(TestTimeout, TestContext.Current.CancellationToken);
+        }
+        finally
+        {
+            await cts.CancelAsync();
+            await readerTask;
+        }
+
+        var result = Assert.Single(actual).GCStartEndStatistics;
+        Assert.Equal((uint)correlationCapacity, result.Index);
+        Assert.Equal(1U, result.Reason);
+        Assert.Single(errors);
+        Assert.IsType<InvalidOperationException>(errors[0]);
+    }
+
+    [Fact]
+    public async Task GCEventListenerIgnoresEndWithoutStartAndProcessesLaterPair()
+    {
+        var actual = new List<GCEventStatistics>(1);
+        var completed = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        using var cts = new CancellationTokenSource(TestTimeout);
+        using var listener = new TestableGCEventListener(value =>
+        {
+            actual.Add(value);
+            completed.TrySetResult();
+            return Task.CompletedTask;
+        });
+
+        var origin = new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+        listener.EnableReading();
+        var readerTask = listener.OnReadResultAsync(cts.Token).AsTask();
+        try
+        {
+            listener.ProcessEvent("GCEnd_V1", origin, [42U, 2U]);
+            listener.ProcessEvent("GCStart_V2", origin.AddTicks(10_000), [43U, 0U, 1U, 0U]);
+            listener.ProcessEvent("GCEnd_V1", origin.AddTicks(15_000), [43U, 0U]);
+
+            await completed.Task.WaitAsync(TestTimeout, TestContext.Current.CancellationToken);
+        }
+        finally
+        {
+            await cts.CancelAsync();
+            await readerTask;
+        }
+
+        Assert.Equal(43U, Assert.Single(actual).GCStartEndStatistics.Index);
+    }
+
+    [Fact]
+    public async Task GCEventListenerIgnoresRestartWithoutSuspendAndProcessesLaterPair()
+    {
+        var actual = new List<GCEventStatistics>(1);
+        var completed = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        using var cts = new CancellationTokenSource(TestTimeout);
+        using var listener = new TestableGCEventListener(value =>
+        {
+            actual.Add(value);
+            completed.TrySetResult();
+            return Task.CompletedTask;
+        });
+
+        var origin = new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+        listener.EnableReading();
+        var readerTask = listener.OnReadResultAsync(cts.Token).AsTask();
+        try
+        {
+            listener.ProcessEvent("GCRestartEEEnd_V1", origin, []);
+            listener.ProcessEvent("GCSuspendEEBegin_V1", origin.AddTicks(10_000), [1U, 123U]);
+            listener.ProcessEvent("GCRestartEEEnd_V1", origin.AddTicks(15_000), []);
+
+            await completed.Task.WaitAsync(TestTimeout, TestContext.Current.CancellationToken);
+        }
+        finally
+        {
+            await cts.CancelAsync();
+            await readerTask;
+        }
+
+        var result = Assert.Single(actual).GCSuspendStatistics;
+        Assert.Equal(1U, result.Reason);
+        Assert.Equal(123U, result.Count);
+        Assert.Equal(0.5, result.DurationMillisec);
+    }
+
+    [Fact]
     public async Task ContentionEventListenerPreservesEveryEventAtChannelCapacity()
     {
         var actual = new List<ContentionEventStatistics>(ChannelCapacity);
@@ -188,8 +536,8 @@ public class EventListenerDataIntegrityTest
         }
     }
 
-    private sealed class TestableGCEventListener(Func<GCEventStatistics, Task> onEventEmit)
-        : GCEventListener(onEventEmit, exception => throw exception)
+    private sealed class TestableGCEventListener(Func<GCEventStatistics, Task> onEventEmit, Action<Exception>? onEventError = null)
+        : GCEventListener(onEventEmit, onEventError ?? (exception => throw exception))
     {
         public void EnableReading() => Enabled = true;
         public void DisableReading() => Enabled = false;


### PR DESCRIPTION
## Summary

- Correlate overlapping GC start/end events by GC index.
- Replace direct modulo storage with a bounded, linearly probed 64-slot table.
- Use atomic ownership instead of locks on the event producer path.
- Handle malformed, missing, stale, and colliding correlation state safely.
- Add independent suspend/restart correlation.
- Support concurrent event writers.

## Intent

Prevent incorrect GC duration/type/reason reporting when background and foreground collections overlap, while keeping the hot path bounded, non-blocking, and allocation-free after initialization.

## Benchmark

- 10,000 synthetic GC start/end pairs in Release mode.
- Steady-state allocation: **0 B** on the processing thread.
- No throughput benchmark was collected.

## Test Results

- Core tests: **25 passed**
- Datadog adapter tests: **1 passed**
- Release build succeeded for .NET 8, 9, and 10.
- Release package generation succeeded.
- Regression coverage includes overlapping and colliding indices, concurrent writers, malformed payloads, missing pairs, bounded-state overflow, and suspend/restart correlation.