### PR TITLE
feat: Precompute Tag and remove Dictionary/ZString from Hotpath

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -10,7 +10,6 @@
     <!-- ClrProfiler.DatadogTracing -->
     <PackageVersion Include="DogStatsD-CSharp-Client" Version="8.0.0" />
     <PackageVersion Include="ZLogger" Version="2.5.10" />
-    <PackageVersion Include="ZString" Version="2.6.0" />
     <!-- Tests -->
     <PackageVersion Include="Microsoft.Extensions.Logging" Version="9.0.1" />
     <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.1" />

--- a/README.md
+++ b/README.md
@@ -58,6 +58,8 @@ tracker.EnableTracker();
 tracker.StartTracker();
 ```
 
+Metric tags are precomputed when the tracker is enabled, before CLR listeners start. Runtime values that are newer than the known tag mappings use a bounded `unknown` tag instead of creating an unbounded cache entry or throwing. Logger metric projection avoids formatting work when debug logging is disabled.
+
 ## Custom Profiling
 
 For advanced scenarios, you can implement custom profiling by creating your own callback handler. Implement the `IClrTrackerCallbackHandler` interface to define custom behavior for each CLR event type.

--- a/src/ClrProfiler.DatadogTracing/ClrProfiler.DatadogTracing.csproj
+++ b/src/ClrProfiler.DatadogTracing/ClrProfiler.DatadogTracing.csproj
@@ -11,9 +11,11 @@
   <ItemGroup>
     <PackageReference Include="DogStatsD-CSharp-Client" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
-    <PackageReference Include="ZString" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\ClrProfiler\ClrProfiler.csproj" />
+  </ItemGroup>
+  <ItemGroup>
+    <InternalsVisibleTo Include="CleProfiler.DatadogTracing.UnitTest" />
   </ItemGroup>
 </Project>

--- a/src/ClrProfiler.DatadogTracing/ClrTracker.cs
+++ b/src/ClrProfiler.DatadogTracing/ClrTracker.cs
@@ -6,6 +6,7 @@ public class ClrTracker : IDisposable
 {
     private readonly ILogger<ClrTracker> _logger;
     private readonly ClrTrackerOptions _options;
+    private readonly Action _initializeMetricTags;
     private readonly object _lifecycleLock = new();
     private ProfilerTracker? _profilerTracker;
     private bool _enabled;
@@ -18,9 +19,15 @@ public class ClrTracker : IDisposable
     }
 
     public ClrTracker(ILoggerFactory loggerFactory, ClrTrackerOptions options)
+        : this(loggerFactory, options, MetricTags.Initialize)
+    {
+    }
+
+    internal ClrTracker(ILoggerFactory loggerFactory, ClrTrackerOptions options, Action initializeMetricTags)
     {
         _logger = loggerFactory.CreateLogger<ClrTracker>();
         _options = options;
+        _initializeMetricTags = initializeMetricTags;
     }
 
     public void EnableTracker()
@@ -31,6 +38,11 @@ public class ClrTracker : IDisposable
             if (_enabled) return;
 
             _logger.LogDebug($"Enable {nameof(ClrTracker)}");
+
+            if (_options.TrackerType is ClrTrackerType.Datadog or ClrTrackerType.Logger)
+            {
+                _initializeMetricTags();
+            }
 
             var profilerOptions = _options.TrackerType switch
             {

--- a/src/ClrProfiler.DatadogTracing/DatadogTracing.cs
+++ b/src/ClrProfiler.DatadogTracing/DatadogTracing.cs
@@ -1,14 +1,10 @@
 using ClrProfiler.Statistics;
-using Cysharp.Text;
 using StatsdClient;
-using System.Collections.Concurrent;
 
 namespace ClrProfiler.DatadogTracing;
 
 public static class DatadogTracing
 {
-    private static readonly ConcurrentDictionary<string, string[]> _tagCache = new();
-
     /// list of event tags
     /// - clr_diagnostics_event.contention.startend_count"
     /// - clr_diagnostics_event.contention.startend_duration_ns"
@@ -29,27 +25,24 @@ public static class DatadogTracing
     // ContentionEvent
     public static void ContentionEventStartEnd(in ContentionEventStatistics statistics)
     {
-        var key = ZString.Concat("contention_type:", statistics.Flag);
-        var tags = _tagCache.GetOrAdd(key, key => [key]);
-        DogStatsd.Increment("clr_diagnostics_event.contention.startend_count", tags: tags);
-        DogStatsd.Gauge("clr_diagnostics_event.contention.startend_duration_ns", statistics.DurationNs, tags: tags);
+        ref readonly var tags = ref MetricTags.GetContention(statistics.Flag);
+        DogStatsd.Increment("clr_diagnostics_event.contention.startend_count", tags: tags.Values);
+        DogStatsd.Gauge("clr_diagnostics_event.contention.startend_duration_ns", statistics.DurationNs, tags: tags.Values);
     }
 
     // GCEvent
     public static void GcEventStartEnd(in GCStartEndStatistics statistics)
     {
-        var key = ZString.Concat("gc_gen:", statistics.Generation, statistics.Type, statistics.Reason);
-        var tags = _tagCache.GetOrAdd(key, (key, stat) => [ZString.Concat($"gc_gen:", stat.Generation), ZString.Concat("gc_type:", stat.Type), ZString.Concat("gc_reason:", stat.GetReasonString())], statistics);
-        DogStatsd.Increment("clr_diagnostics_event.gc.startend_count", tags: tags);
-        DogStatsd.Gauge("clr_diagnostics_event.gc.startend_duration_ms", statistics.DurationMillsec, tags: tags);
+        ref readonly var tags = ref MetricTags.GetGcStartEnd(statistics.Generation, statistics.Type, statistics.Reason);
+        DogStatsd.Increment("clr_diagnostics_event.gc.startend_count", tags: tags.Values);
+        DogStatsd.Gauge("clr_diagnostics_event.gc.startend_duration_ms", statistics.DurationMillsec, tags: tags.Values);
     }
 
     public static void GcEventSuspend(in GCSuspendStatistics statistics)
     {
-        var key = ZString.Concat("gc_suspend:", statistics.Reason);
-        var tags = _tagCache.GetOrAdd(key, (key, stat) => [ZString.Concat("gc_suspend_reason:", stat.GetReasonString())], statistics);
-        DogStatsd.Counter("clr_diagnostics_event.gc.suspend_object_count", statistics.Count, tags: tags);
-        DogStatsd.Gauge("clr_diagnostics_event.gc.suspend_duration_ms", statistics.DurationMillisec, tags: tags);
+        ref readonly var tags = ref MetricTags.GetGcSuspend(statistics.Reason);
+        DogStatsd.Counter("clr_diagnostics_event.gc.suspend_object_count", statistics.Count, tags: tags.Values);
+        DogStatsd.Gauge("clr_diagnostics_event.gc.suspend_duration_ms", statistics.DurationMillisec, tags: tags.Values);
     }
 
     // ThreadPoolEvent
@@ -59,10 +52,9 @@ public static class DatadogTracing
     }
     public static void ThreadPoolEventAdjustment(in ThreadPoolAdjustmentStatistics statistics)
     {
-        var key = ZString.Concat("thread_adjust_reason", statistics.Reason);
-        var tags = _tagCache.GetOrAdd(key, (key, stat) => [ZString.Concat("thread_adjust_reason:", stat.GetReasonString())], statistics);
-        DogStatsd.Gauge("clr_diagnostics_event.threadpool.adjustment_avg_throughput", statistics.AverageThrouput, tags: tags);
-        DogStatsd.Gauge("clr_diagnostics_event.threadpool.adjustment_new_workerthreads_count", statistics.NewWorkerThreads, tags: tags);
+        ref readonly var tags = ref MetricTags.GetThreadAdjustment(statistics.Reason);
+        DogStatsd.Gauge("clr_diagnostics_event.threadpool.adjustment_avg_throughput", statistics.AverageThrouput, tags: tags.Values);
+        DogStatsd.Gauge("clr_diagnostics_event.threadpool.adjustment_new_workerthreads_count", statistics.NewWorkerThreads, tags: tags.Values);
     }
     public static void ThreadPoolStarvationEventAdjustment(in ThreadPoolAdjustmentStatistics statistics)
     {
@@ -99,27 +91,18 @@ public static class DatadogTracing
     // GC
     public static void GcInfoTimerGauge(in GCInfoStatistics statistics)
     {
-        var baseTagkey = ZString.Concat("gc_mode", statistics.GCMode, statistics.LatencyMode, statistics.CompactionMode);
-        var baseTag = _tagCache.GetOrAdd(baseTagkey, (key, stat) => [
-            ZString.Concat("gc_mode:", stat.GetGCModeString()),
-            ZString.Concat("latency_mode:", stat.GetLatencyModeString()),
-            ZString.Concat("compaction_mode:", stat.GetCompactionModeString())
-        ], statistics);
-        var gen0Tags = _tagCache.GetOrAdd(ZString.Concat("gen0", baseTagkey), key => baseTag.Prepend($"gc_gen:0").ToArray());
-        var gen1Tags = _tagCache.GetOrAdd(ZString.Concat("gen1", baseTagkey), key => baseTag.Prepend($"gc_gen:1").ToArray());
-        var gen2Tags = _tagCache.GetOrAdd(ZString.Concat("gen2", baseTagkey), key => baseTag.Prepend($"gc_gen:2").ToArray());
-        var genLohTags = _tagCache.GetOrAdd(ZString.Concat("genLoh", baseTagkey), key => baseTag.Prepend($"gc_gen:loh").ToArray());
+        ref readonly var tags = ref MetricTags.GetGcInfo(statistics.GCMode, statistics.LatencyMode, statistics.CompactionMode);
 
-        DogStatsd.Gauge("clr_diagnostics_timer.gc.heap_size_bytes", statistics.HeapSize, tags: baseTag);
-        DogStatsd.Gauge("clr_diagnostics_timer.gc.total_allocation_bytes", statistics.TotalAllocationBytes, tags: baseTag);
-        DogStatsd.Gauge("clr_diagnostics_timer.gc.gc_count", statistics.Gen0Count, tags: gen0Tags);
-        DogStatsd.Gauge("clr_diagnostics_timer.gc.gc_count", statistics.Gen1Count, tags: gen1Tags);
-        DogStatsd.Gauge("clr_diagnostics_timer.gc.gc_count", statistics.Gen2Count, tags: gen2Tags);
-        DogStatsd.Gauge("clr_diagnostics_timer.gc.gc_size", statistics.Gen0Size, tags: gen0Tags);
-        DogStatsd.Gauge("clr_diagnostics_timer.gc.gc_size", statistics.Gen1Size, tags: gen1Tags);
-        DogStatsd.Gauge("clr_diagnostics_timer.gc.gc_size", statistics.Gen2Size, tags: gen2Tags);
-        DogStatsd.Gauge("clr_diagnostics_timer.gc.gc_size", statistics.LohSize, tags: genLohTags);
-        DogStatsd.Gauge("clr_diagnostics_timer.gc.time_in_gc_percent", statistics.TimeInGc, tags: baseTag);
+        DogStatsd.Gauge("clr_diagnostics_timer.gc.heap_size_bytes", statistics.HeapSize, tags: tags.Base.Values);
+        DogStatsd.Gauge("clr_diagnostics_timer.gc.total_allocation_bytes", statistics.TotalAllocationBytes, tags: tags.Base.Values);
+        DogStatsd.Gauge("clr_diagnostics_timer.gc.gc_count", statistics.Gen0Count, tags: tags.Gen0.Values);
+        DogStatsd.Gauge("clr_diagnostics_timer.gc.gc_count", statistics.Gen1Count, tags: tags.Gen1.Values);
+        DogStatsd.Gauge("clr_diagnostics_timer.gc.gc_count", statistics.Gen2Count, tags: tags.Gen2.Values);
+        DogStatsd.Gauge("clr_diagnostics_timer.gc.gc_size", statistics.Gen0Size, tags: tags.Gen0.Values);
+        DogStatsd.Gauge("clr_diagnostics_timer.gc.gc_size", statistics.Gen1Size, tags: tags.Gen1.Values);
+        DogStatsd.Gauge("clr_diagnostics_timer.gc.gc_size", statistics.Gen2Size, tags: tags.Gen2.Values);
+        DogStatsd.Gauge("clr_diagnostics_timer.gc.gc_size", statistics.LohSize, tags: tags.Loh.Values);
+        DogStatsd.Gauge("clr_diagnostics_timer.gc.time_in_gc_percent", statistics.TimeInGc, tags: tags.Base.Values);
     }
 
     // Process

--- a/src/ClrProfiler.DatadogTracing/DatadogTracing.cs
+++ b/src/ClrProfiler.DatadogTracing/DatadogTracing.cs
@@ -5,126 +5,82 @@ namespace ClrProfiler.DatadogTracing;
 
 public static class DatadogTracing
 {
-    /// list of event tags
-    /// - clr_diagnostics_event.contention.startend_count"
-    /// - clr_diagnostics_event.contention.startend_duration_ns"
-    ///     contention_flag|managed|native
-    /// - clr_diagnostics_event.gc.startend_count            // count
-    /// - clr_diagnostics_event.gc.startend_duration_ms      // gauge
-    ///     gc_gen:0|1|2
-    ///     gc_type:blocking_outsite|background|blocking_during_gc
-    ///     gc_reason:soh|induced|low_memory|empty|loh|oos_soh|oos_loh|incuded_non_forceblock
-    /// - clr_diagnostics_event.gc.suspend_count             // count
-    /// - clr_diagnostics_event.gc.suspend_duration_ms       // gauge
-    ///     gc_suspend_reason:other|gc|appdomain_shudown|code_pitch|shutdown|debugger|prep_gc
-    /// - clr_diagnostics_event.threadpool.available_workerthread_count // gauge
-    /// - clr_diagnostics_event.threadpool.adjustment_avg_throughput // gauge
-    /// - clr_diagnostics_event.threadpool.adjustment_new_workerthreads_count // gauge
-    ///     threadpool_adjustment_reason:warmup|initializing|random_move|climbing_move|change_point|stabilizing|starvation|timeout
-
     // ContentionEvent
     public static void ContentionEventStartEnd(in ContentionEventStatistics statistics)
     {
         ref readonly var tags = ref MetricTags.GetContention(statistics.Flag);
-        DogStatsd.Increment("clr_diagnostics_event.contention.startend_count", tags: tags.Values);
-        DogStatsd.Gauge("clr_diagnostics_event.contention.startend_duration_ns", statistics.DurationNs, tags: tags.Values);
+        DogStatsd.Increment(MetricNames.Event.ContentionStartEndCount, tags: tags.Values);
+        DogStatsd.Gauge(MetricNames.Event.ContentionStartEndDurationNs, statistics.DurationNs, tags: tags.Values);
     }
 
     // GCEvent
     public static void GcEventStartEnd(in GCStartEndStatistics statistics)
     {
         ref readonly var tags = ref MetricTags.GetGcStartEnd(statistics.Generation, statistics.Type, statistics.Reason);
-        DogStatsd.Increment("clr_diagnostics_event.gc.startend_count", tags: tags.Values);
-        DogStatsd.Gauge("clr_diagnostics_event.gc.startend_duration_ms", statistics.DurationMillsec, tags: tags.Values);
+        DogStatsd.Increment(MetricNames.Event.GcStartEndCount, tags: tags.Values);
+        DogStatsd.Gauge(MetricNames.Event.GcStartEndDurationMs, statistics.DurationMillsec, tags: tags.Values);
     }
 
     public static void GcEventSuspend(in GCSuspendStatistics statistics)
     {
         ref readonly var tags = ref MetricTags.GetGcSuspend(statistics.Reason);
-        DogStatsd.Counter("clr_diagnostics_event.gc.suspend_object_count", statistics.Count, tags: tags.Values);
-        DogStatsd.Gauge("clr_diagnostics_event.gc.suspend_duration_ms", statistics.DurationMillisec, tags: tags.Values);
+        DogStatsd.Counter(MetricNames.Event.GcSuspendObjectCount, statistics.Count, tags: tags.Values);
+        DogStatsd.Gauge(MetricNames.Event.GcSuspendDurationMs, statistics.DurationMillisec, tags: tags.Values);
     }
 
     // ThreadPoolEvent
     public static void ThreadPoolEventWorker(in ThreadPoolWorkerStatistics statistics)
     {
-        DogStatsd.Gauge("clr_diagnostics_event.threadpool.available_workerthread_count", statistics.ActiveWrokerThreads);
+        DogStatsd.Gauge(MetricNames.Event.ThreadPoolAvailableWorkerThreadCount, statistics.ActiveWrokerThreads);
     }
     public static void ThreadPoolEventAdjustment(in ThreadPoolAdjustmentStatistics statistics)
     {
         ref readonly var tags = ref MetricTags.GetThreadAdjustment(statistics.Reason);
-        DogStatsd.Gauge("clr_diagnostics_event.threadpool.adjustment_avg_throughput", statistics.AverageThrouput, tags: tags.Values);
-        DogStatsd.Gauge("clr_diagnostics_event.threadpool.adjustment_new_workerthreads_count", statistics.NewWorkerThreads, tags: tags.Values);
+        DogStatsd.Gauge(MetricNames.Event.ThreadPoolAdjustmentAverageThroughput, statistics.AverageThrouput, tags: tags.Values);
+        DogStatsd.Gauge(MetricNames.Event.ThreadPoolAdjustmentNewWorkerThreadsCount, statistics.NewWorkerThreads, tags: tags.Values);
     }
     public static void ThreadPoolStarvationEventAdjustment(in ThreadPoolAdjustmentStatistics statistics)
     {
         DogStatsd.Event("ThreadPool Starvation detected", ".NET CLR automatically expanding ThreadPool, but this results slow down system. Watch out for error increase and take action to expan thread pool in advance.", alertType: "warning", aggregationKey: "host");
     }
 
-
-    /// list of timer tags
-    /// - clr_diagnostics_timer.gc.heap_size // gauge
-    /// - clr_diagnostics_timer.gc.total_allocation_bytes // gauge
-    /// - clr_diagnostics_timer.gc.gen0_count // gauge
-    /// - clr_diagnostics_timer.gc.gen1_count // gauge
-    /// - clr_diagnostics_timer.gc.gen2_count // gauge
-    /// - clr_diagnostics_timer.gc.gen0_size // gauge
-    /// - clr_diagnostics_timer.gc.gen1_size // gauge
-    /// - clr_diagnostics_timer.gc.gen2_size // gauge
-    /// - clr_diagnostics_timer.gc.loh_size // gauge
-    /// - clr_diagnostics_timer.gc.time_in_gc_percent // gauge
-    /// - clr_diagnostics_timer.process.cpu // gauge
-    /// - clr_diagnostics_timer.process.private_bytes // gauge
-    /// - clr_diagnostics_timer.process.working_sets // gauge
-    /// - clr_diagnostics_timer.thread.available_worker_threads // gauge
-    /// - clr_diagnostics_timer.thread.available_completion_port_threads // gauge
-    /// - clr_diagnostics_timer.thread.max_worker_threads // gauge
-    /// - clr_diagnostics_timer.thread.max_completion_port_threads // gauge
-    /// - clr_diagnostics_timer.thread.using_worker_threads // gauge
-    /// - clr_diagnostics_timer.thread.using_completion_port_threads // gauge
-    /// - clr_diagnostics_timer.thread.thread_count // gauge
-    /// - clr_diagnostics_timer.thread.queue_length // gauge
-    /// - clr_diagnostics_timer.thread.lock_contention_count // gauge
-    /// - clr_diagnostics_timer.thread.completed_items_count // gauge
-    /// - clr_diagnostics_timer.thread.available_completion_port_threads // gauge
-
     // GC
     public static void GcInfoTimerGauge(in GCInfoStatistics statistics)
     {
         ref readonly var tags = ref MetricTags.GetGcInfo(statistics.GCMode, statistics.LatencyMode, statistics.CompactionMode);
 
-        DogStatsd.Gauge("clr_diagnostics_timer.gc.heap_size_bytes", statistics.HeapSize, tags: tags.Base.Values);
-        DogStatsd.Gauge("clr_diagnostics_timer.gc.total_allocation_bytes", statistics.TotalAllocationBytes, tags: tags.Base.Values);
-        DogStatsd.Gauge("clr_diagnostics_timer.gc.gc_count", statistics.Gen0Count, tags: tags.Gen0.Values);
-        DogStatsd.Gauge("clr_diagnostics_timer.gc.gc_count", statistics.Gen1Count, tags: tags.Gen1.Values);
-        DogStatsd.Gauge("clr_diagnostics_timer.gc.gc_count", statistics.Gen2Count, tags: tags.Gen2.Values);
-        DogStatsd.Gauge("clr_diagnostics_timer.gc.gc_size", statistics.Gen0Size, tags: tags.Gen0.Values);
-        DogStatsd.Gauge("clr_diagnostics_timer.gc.gc_size", statistics.Gen1Size, tags: tags.Gen1.Values);
-        DogStatsd.Gauge("clr_diagnostics_timer.gc.gc_size", statistics.Gen2Size, tags: tags.Gen2.Values);
-        DogStatsd.Gauge("clr_diagnostics_timer.gc.gc_size", statistics.LohSize, tags: tags.Loh.Values);
-        DogStatsd.Gauge("clr_diagnostics_timer.gc.time_in_gc_percent", statistics.TimeInGc, tags: tags.Base.Values);
+        DogStatsd.Gauge(MetricNames.Timer.GcHeapSizeBytes, statistics.HeapSize, tags: tags.Base.Values);
+        DogStatsd.Gauge(MetricNames.Timer.GcTotalAllocationBytes, statistics.TotalAllocationBytes, tags: tags.Base.Values);
+        DogStatsd.Gauge(MetricNames.Timer.GcCount, statistics.Gen0Count, tags: tags.Gen0.Values);
+        DogStatsd.Gauge(MetricNames.Timer.GcCount, statistics.Gen1Count, tags: tags.Gen1.Values);
+        DogStatsd.Gauge(MetricNames.Timer.GcCount, statistics.Gen2Count, tags: tags.Gen2.Values);
+        DogStatsd.Gauge(MetricNames.Timer.GcSize, statistics.Gen0Size, tags: tags.Gen0.Values);
+        DogStatsd.Gauge(MetricNames.Timer.GcSize, statistics.Gen1Size, tags: tags.Gen1.Values);
+        DogStatsd.Gauge(MetricNames.Timer.GcSize, statistics.Gen2Size, tags: tags.Gen2.Values);
+        DogStatsd.Gauge(MetricNames.Timer.GcSize, statistics.LohSize, tags: tags.Loh.Values);
+        DogStatsd.Gauge(MetricNames.Timer.GcTimeInGcPercent, statistics.TimeInGc, tags: tags.Base.Values);
     }
 
     // Process
     public static void ProcessInfoTimerGauge(in ProcessInfoStatistics statistics)
     {
-        DogStatsd.Gauge("clr_diagnostics_timer.process.cpu", statistics.Cpu);
-        DogStatsd.Gauge("clr_diagnostics_timer.process.private_bytes", statistics.PrivateBytes);
-        DogStatsd.Gauge("clr_diagnostics_timer.process.working_sets", statistics.WorkingSet);
+        DogStatsd.Gauge(MetricNames.Timer.ProcessCpu, statistics.Cpu);
+        DogStatsd.Gauge(MetricNames.Timer.ProcessPrivateBytes, statistics.PrivateBytes);
+        DogStatsd.Gauge(MetricNames.Timer.ProcessWorkingSets, statistics.WorkingSet);
     }
 
     // Thread
     public static void ThreadInfoTimerGauge(in ThreadInfoStatistics statistics)
     {
-        DogStatsd.Gauge("clr_diagnostics_timer.thread.available_worker_threads", statistics.AvailableWorkerThreads);
-        DogStatsd.Gauge("clr_diagnostics_timer.thread.available_completion_port_threads", statistics.AvailableCompletionPortThreads);
-        DogStatsd.Gauge("clr_diagnostics_timer.thread.max_worker_threads", statistics.MaxWorkerThreads);
-        DogStatsd.Gauge("clr_diagnostics_timer.thread.max_completion_port_threads", statistics.MaxCompletionPortThreads);
-        DogStatsd.Gauge("clr_diagnostics_timer.thread.using_worker_threads", statistics.UsingWorkerThreads);
-        DogStatsd.Gauge("clr_diagnostics_timer.thread.using_completion_port_threads", statistics.UsingCompletionPortThreads);
-        DogStatsd.Gauge("clr_diagnostics_timer.thread.thread_count", statistics.ThreadCount);
-        DogStatsd.Gauge("clr_diagnostics_timer.thread.queue_length", statistics.QueueLength);
-        DogStatsd.Gauge("clr_diagnostics_timer.thread.lock_contention_count", statistics.LockContentionCount);
-        DogStatsd.Gauge("clr_diagnostics_timer.thread.completed_items_count", statistics.CompletedItemsCount);
+        DogStatsd.Gauge(MetricNames.Timer.ThreadAvailableWorkerThreads, statistics.AvailableWorkerThreads);
+        DogStatsd.Gauge(MetricNames.Timer.ThreadAvailableCompletionPortThreads, statistics.AvailableCompletionPortThreads);
+        DogStatsd.Gauge(MetricNames.Timer.ThreadMaxWorkerThreads, statistics.MaxWorkerThreads);
+        DogStatsd.Gauge(MetricNames.Timer.ThreadMaxCompletionPortThreads, statistics.MaxCompletionPortThreads);
+        DogStatsd.Gauge(MetricNames.Timer.ThreadUsingWorkerThreads, statistics.UsingWorkerThreads);
+        DogStatsd.Gauge(MetricNames.Timer.ThreadUsingCompletionPortThreads, statistics.UsingCompletionPortThreads);
+        DogStatsd.Gauge(MetricNames.Timer.ThreadCount, statistics.ThreadCount);
+        DogStatsd.Gauge(MetricNames.Timer.ThreadQueueLength, statistics.QueueLength);
+        DogStatsd.Gauge(MetricNames.Timer.ThreadLockContentionCount, statistics.LockContentionCount);
+        DogStatsd.Gauge(MetricNames.Timer.ThreadCompletedItemsCount, statistics.CompletedItemsCount);
     }
 }

--- a/src/ClrProfiler.DatadogTracing/LoggerTracing.cs
+++ b/src/ClrProfiler.DatadogTracing/LoggerTracing.cs
@@ -3,127 +3,97 @@ using Microsoft.Extensions.Logging;
 
 namespace ClrProfiler.DatadogTracing;
 
-public static class LoggerTracing
+public static partial class LoggerTracing
 {
-    /// list of event tags
-    /// - clr_diagnostics_event.contention.startend_count"
-    /// - clr_diagnostics_event.contention.startend_duration_ns"
-    ///     contention_flag|managed|native
-    /// - clr_diagnostics_event.gc.startend_count            // count
-    /// - clr_diagnostics_event.gc.startend_duration_ms      // gauge
-    ///     gc_gen:0|1|2
-    ///     gc_type:blocking_outsite|background|blocking_during_gc
-    ///     gc_reason:soh|induced|low_memory|empty|loh|oos_soh|oos_loh|incuded_non_forceblock
-    /// - clr_diagnostics_event.gc.suspend_count             // count
-    /// - clr_diagnostics_event.gc.suspend_duration_ms       // gauge
-    ///     gc_suspend_reason:other|gc|appdomain_shudown|code_pitch|shutdown|debugger|prep_gc
-    /// - clr_diagnostics_event.threadpool.available_workerthread_count // gauge
-    /// - clr_diagnostics_event.threadpool.adjustment_avg_throughput // gauge
-    /// - clr_diagnostics_event.threadpool.adjustment_new_workerthreads_count // gauge
-    ///     threadpool_adjustment_reason:warmup|initializing|random_move|climbing_move|change_point|stabilizing|starvation|timeout
-
-    // ContentionEvent
     public static void ContentionEventStartEnd(in ContentionEventStatistics statistics, ILogger logger)
     {
         ref readonly var tags = ref MetricTags.GetContention(statistics.Flag);
-        logger.LogDebug($"clr_diagnostics_event.contention.startend_count: 1, tags: {tags.Text}");
-        logger.LogDebug($"clr_diagnostics_event.contention.startend_duration_ns: {statistics.DurationNs}, tags: {tags.Text}");
+        LogIntMetric(logger, "clr_diagnostics_event.contention.startend_count", 1, tags.Text);
+        LogDoubleMetric(logger, "clr_diagnostics_event.contention.startend_duration_ns", statistics.DurationNs, tags.Text);
     }
 
-    // GCEvent
     public static void GcEventStartEnd(in GCStartEndStatistics statistics, ILogger logger)
     {
         ref readonly var tags = ref MetricTags.GetGcStartEnd(statistics.Generation, statistics.Type, statistics.Reason);
-        logger.LogDebug($"clr_diagnostics_event.gc.startend_count: 1, tags: {tags.Text}");
-        logger.LogDebug($"clr_diagnostics_event.gc.startend_duration_ms: {statistics.DurationMillsec}, tags: {tags.Text}");
+        LogIntMetric(logger, "clr_diagnostics_event.gc.startend_count", 1, tags.Text);
+        LogDoubleMetric(logger, "clr_diagnostics_event.gc.startend_duration_ms", statistics.DurationMillsec, tags.Text);
     }
 
     public static void GcEventSuspend(in GCSuspendStatistics statistics, ILogger logger)
     {
         ref readonly var tags = ref MetricTags.GetGcSuspend(statistics.Reason);
-        logger.LogDebug($"clr_diagnostics_event.gc.suspend_object_count: {statistics.Count}, tags: {tags.Text}");
-        logger.LogDebug($"clr_diagnostics_event.gc.suspend_duration_ms: {statistics.DurationMillisec}, tags: {tags.Text}");
+        LogUIntMetric(logger, "clr_diagnostics_event.gc.suspend_object_count", statistics.Count, tags.Text);
+        LogDoubleMetric(logger, "clr_diagnostics_event.gc.suspend_duration_ms", statistics.DurationMillisec, tags.Text);
     }
 
-    // ThreadPoolEvent
     public static void ThreadPoolEventWorker(in ThreadPoolWorkerStatistics statistics, ILogger logger)
     {
-        logger.LogDebug($"clr_diagnostics_event.threadpool.available_workerthread_count: {statistics.ActiveWrokerThreads}, tags: ");
+        LogUIntMetric(logger, "clr_diagnostics_event.threadpool.available_workerthread_count", statistics.ActiveWrokerThreads, string.Empty);
     }
+
     public static void ThreadPoolEventAdjustment(in ThreadPoolAdjustmentStatistics statistics, ILogger logger)
     {
         ref readonly var tags = ref MetricTags.GetThreadAdjustment(statistics.Reason);
-        logger.LogDebug($"clr_diagnostics_event.threadpool.adjustment_avg_throughput: {statistics.AverageThrouput}, tags: {tags.Text}");
-        logger.LogDebug($"clr_diagnostics_event.threadpool.adjustment_new_workerthreads_count: {statistics.NewWorkerThreads}, tags: {tags.Text}");
+        LogDoubleMetric(logger, "clr_diagnostics_event.threadpool.adjustment_avg_throughput", statistics.AverageThrouput, tags.Text);
+        LogUIntMetric(logger, "clr_diagnostics_event.threadpool.adjustment_new_workerthreads_count", statistics.NewWorkerThreads, tags.Text);
     }
+
     public static void ThreadPoolStarvationEventAdjustment(in ThreadPoolAdjustmentStatistics statistics, ILogger logger)
     {
-        logger.LogDebug($"title: ThreadPool Starvation detected, text: .NET CLR automatically expanding ThreadPool, but this results slow down system. Watch out for error increase and take action to expan thread pool in advance., alertType: warning, aggregationKey: host");
+        LogThreadPoolStarvation(logger);
     }
 
-
-    /// list of timer tags
-    /// - clr_diagnostics_timer.gc.heap_size // gauge
-    /// - clr_diagnostics_timer.gc.total_allocation_bytes // gauge
-    /// - clr_diagnostics_timer.gc.gen0_count // gauge
-    /// - clr_diagnostics_timer.gc.gen1_count // gauge
-    /// - clr_diagnostics_timer.gc.gen2_count // gauge
-    /// - clr_diagnostics_timer.gc.gen0_size // gauge
-    /// - clr_diagnostics_timer.gc.gen1_size // gauge
-    /// - clr_diagnostics_timer.gc.gen2_size // gauge
-    /// - clr_diagnostics_timer.gc.loh_size // gauge
-    /// - clr_diagnostics_timer.gc.time_in_gc_percent // gauge
-    /// - clr_diagnostics_timer.process.cpu // gauge
-    /// - clr_diagnostics_timer.process.private_bytes // gauge
-    /// - clr_diagnostics_timer.process.working_sets // gauge
-    /// - clr_diagnostics_timer.thread.available_worker_threads // gauge
-    /// - clr_diagnostics_timer.thread.available_completion_port_threads // gauge
-    /// - clr_diagnostics_timer.thread.max_worker_threads // gauge
-    /// - clr_diagnostics_timer.thread.max_completion_port_threads // gauge
-    /// - clr_diagnostics_timer.thread.using_worker_threads // gauge
-    /// - clr_diagnostics_timer.thread.using_completion_port_threads // gauge
-    /// - clr_diagnostics_timer.thread.thread_count // gauge
-    /// - clr_diagnostics_timer.thread.queue_length // gauge
-    /// - clr_diagnostics_timer.thread.lock_contention_count // gauge
-    /// - clr_diagnostics_timer.thread.completed_items_count // gauge
-    /// - clr_diagnostics_timer.thread.available_completion_port_threads // gauge
-
-    // GC
     public static void GcInfoTimerGauge(in GCInfoStatistics statistics, ILogger logger)
     {
         ref readonly var tags = ref MetricTags.GetGcInfo(statistics.GCMode, statistics.LatencyMode, statistics.CompactionMode);
-        logger.LogDebug($"clr_diagnostics_timer.gc.heap_size_bytes: {statistics.HeapSize}, tags: {tags.Base.Text}");
-        logger.LogDebug($"clr_diagnostics_timer.gc.total_allocation_bytes: {statistics.TotalAllocationBytes}, tags: {tags.Base.Text}");
-        logger.LogDebug($"clr_diagnostics_timer.gc.gc_count: {statistics.Gen0Count}, tags: {tags.Gen0.Text}");
-        logger.LogDebug($"clr_diagnostics_timer.gc.gc_count: {statistics.Gen1Count}, tags: {tags.Gen1.Text}");
-        logger.LogDebug($"clr_diagnostics_timer.gc.gc_count: {statistics.Gen2Count}, tags: {tags.Gen2.Text}");
-        logger.LogDebug($"clr_diagnostics_timer.gc.gc_size: {statistics.Gen0Size}, tags: {tags.Gen0.Text}");
-        logger.LogDebug($"clr_diagnostics_timer.gc.gc_size: {statistics.Gen1Size}, tags: {tags.Gen1.Text}");
-        logger.LogDebug($"clr_diagnostics_timer.gc.gc_size: {statistics.Gen2Size}, tags: {tags.Gen2.Text}");
-        logger.LogDebug($"clr_diagnostics_timer.gc.gc_size: {statistics.LohSize}, tags: {tags.Loh.Text}");
-        logger.LogDebug($"clr_diagnostics_timer.gc.time_in_gc_percent: {statistics.TimeInGc}, tags: {tags.Base.Text}");
+        LogLongMetric(logger, "clr_diagnostics_timer.gc.heap_size_bytes", statistics.HeapSize, tags.Base.Text);
+        LogLongMetric(logger, "clr_diagnostics_timer.gc.total_allocation_bytes", statistics.TotalAllocationBytes, tags.Base.Text);
+        LogIntMetric(logger, "clr_diagnostics_timer.gc.gc_count", statistics.Gen0Count, tags.Gen0.Text);
+        LogIntMetric(logger, "clr_diagnostics_timer.gc.gc_count", statistics.Gen1Count, tags.Gen1.Text);
+        LogIntMetric(logger, "clr_diagnostics_timer.gc.gc_count", statistics.Gen2Count, tags.Gen2.Text);
+        LogULongMetric(logger, "clr_diagnostics_timer.gc.gc_size", statistics.Gen0Size, tags.Gen0.Text);
+        LogULongMetric(logger, "clr_diagnostics_timer.gc.gc_size", statistics.Gen1Size, tags.Gen1.Text);
+        LogULongMetric(logger, "clr_diagnostics_timer.gc.gc_size", statistics.Gen2Size, tags.Gen2.Text);
+        LogULongMetric(logger, "clr_diagnostics_timer.gc.gc_size", statistics.LohSize, tags.Loh.Text);
+        LogIntMetric(logger, "clr_diagnostics_timer.gc.time_in_gc_percent", statistics.TimeInGc, tags.Base.Text);
     }
 
-    // Process
     public static void ProcessInfoTimerGauge(in ProcessInfoStatistics statistics, ILogger logger)
     {
-        logger.LogDebug($"clr_diagnostics_timer.process.cpu: {statistics.Cpu}, tags: ");
-        logger.LogDebug($"clr_diagnostics_timer.process.private_bytes: {statistics.PrivateBytes}, tags: ");
-        logger.LogDebug($"clr_diagnostics_timer.process.working_sets: {statistics.WorkingSet}, tags: ");
+        LogDoubleMetric(logger, "clr_diagnostics_timer.process.cpu", statistics.Cpu, string.Empty);
+        LogLongMetric(logger, "clr_diagnostics_timer.process.private_bytes", statistics.PrivateBytes, string.Empty);
+        LogLongMetric(logger, "clr_diagnostics_timer.process.working_sets", statistics.WorkingSet, string.Empty);
     }
 
-    // Thread
     public static void ThreadInfoTimerGauge(in ThreadInfoStatistics statistics, ILogger logger)
     {
-        logger.LogDebug($"clr_diagnostics_timer.thread.available_worker_threads: {statistics.AvailableWorkerThreads}, tags: ");
-        logger.LogDebug($"clr_diagnostics_timer.thread.available_completion_port_threads: {statistics.AvailableCompletionPortThreads}, tags: ");
-        logger.LogDebug($"clr_diagnostics_timer.thread.max_worker_threads: {statistics.MaxWorkerThreads}, tags: ");
-        logger.LogDebug($"clr_diagnostics_timer.thread.max_completion_port_threads: {statistics.MaxCompletionPortThreads}, tags: ");
-        logger.LogDebug($"clr_diagnostics_timer.thread.using_worker_threads: {statistics.UsingWorkerThreads}, tags: ");
-        logger.LogDebug($"clr_diagnostics_timer.thread.using_completion_port_threads: {statistics.UsingCompletionPortThreads}, tags: ");
-        logger.LogDebug($"clr_diagnostics_timer.thread.thread_count: {statistics.ThreadCount}, tags: ");
-        logger.LogDebug($"clr_diagnostics_timer.thread.queue_length: {statistics.QueueLength}, tags: ");
-        logger.LogDebug($"clr_diagnostics_timer.thread.lock_contention_count: {statistics.LockContentionCount}, tags: ");
-        logger.LogDebug($"clr_diagnostics_timer.thread.completed_items_count: {statistics.CompletedItemsCount}, tags: ");
+        LogIntMetric(logger, "clr_diagnostics_timer.thread.available_worker_threads", statistics.AvailableWorkerThreads, string.Empty);
+        LogIntMetric(logger, "clr_diagnostics_timer.thread.available_completion_port_threads", statistics.AvailableCompletionPortThreads, string.Empty);
+        LogIntMetric(logger, "clr_diagnostics_timer.thread.max_worker_threads", statistics.MaxWorkerThreads, string.Empty);
+        LogIntMetric(logger, "clr_diagnostics_timer.thread.max_completion_port_threads", statistics.MaxCompletionPortThreads, string.Empty);
+        LogIntMetric(logger, "clr_diagnostics_timer.thread.using_worker_threads", statistics.UsingWorkerThreads, string.Empty);
+        LogIntMetric(logger, "clr_diagnostics_timer.thread.using_completion_port_threads", statistics.UsingCompletionPortThreads, string.Empty);
+        LogIntMetric(logger, "clr_diagnostics_timer.thread.thread_count", statistics.ThreadCount, string.Empty);
+        LogLongMetric(logger, "clr_diagnostics_timer.thread.queue_length", statistics.QueueLength, string.Empty);
+        LogLongMetric(logger, "clr_diagnostics_timer.thread.lock_contention_count", statistics.LockContentionCount, string.Empty);
+        LogLongMetric(logger, "clr_diagnostics_timer.thread.completed_items_count", statistics.CompletedItemsCount, string.Empty);
     }
+
+    [LoggerMessage(Level = LogLevel.Debug, Message = "{MetricName}: {Value}, tags: {Tags}")]
+    private static partial void LogIntMetric(ILogger logger, string metricName, int value, string tags);
+
+    [LoggerMessage(Level = LogLevel.Debug, Message = "{MetricName}: {Value}, tags: {Tags}")]
+    private static partial void LogUIntMetric(ILogger logger, string metricName, uint value, string tags);
+
+    [LoggerMessage(Level = LogLevel.Debug, Message = "{MetricName}: {Value}, tags: {Tags}")]
+    private static partial void LogLongMetric(ILogger logger, string metricName, long value, string tags);
+
+    [LoggerMessage(Level = LogLevel.Debug, Message = "{MetricName}: {Value}, tags: {Tags}")]
+    private static partial void LogULongMetric(ILogger logger, string metricName, ulong value, string tags);
+
+    [LoggerMessage(Level = LogLevel.Debug, Message = "{MetricName}: {Value}, tags: {Tags}")]
+    private static partial void LogDoubleMetric(ILogger logger, string metricName, double value, string tags);
+
+    [LoggerMessage(Level = LogLevel.Debug, Message = "title: ThreadPool Starvation detected, text: .NET CLR automatically expanding ThreadPool, but this results slow down system. Watch out for error increase and take action to expan thread pool in advance., alertType: warning, aggregationKey: host")]
+    private static partial void LogThreadPoolStarvation(ILogger logger);
 }

--- a/src/ClrProfiler.DatadogTracing/LoggerTracing.cs
+++ b/src/ClrProfiler.DatadogTracing/LoggerTracing.cs
@@ -1,14 +1,10 @@
 using ClrProfiler.Statistics;
-using Cysharp.Text;
 using Microsoft.Extensions.Logging;
-using System.Collections.Concurrent;
 
 namespace ClrProfiler.DatadogTracing;
 
 public static class LoggerTracing
 {
-    private static readonly ConcurrentDictionary<string, string[]> _tagCache = new();
-
     /// list of event tags
     /// - clr_diagnostics_event.contention.startend_count"
     /// - clr_diagnostics_event.contention.startend_duration_ns"
@@ -29,27 +25,24 @@ public static class LoggerTracing
     // ContentionEvent
     public static void ContentionEventStartEnd(in ContentionEventStatistics statistics, ILogger logger)
     {
-        var key = ZString.Concat("contention_type:", statistics.Flag);
-        var tags = _tagCache.GetOrAdd(key, key => [key]);
-        logger.LogDebug($"clr_diagnostics_event.contention.startend_count: 1, tags: {TagsToString(tags)}");
-        logger.LogDebug($"clr_diagnostics_event.contention.startend_duration_ns: {statistics.DurationNs}, tags: {TagsToString(tags)}");
+        ref readonly var tags = ref MetricTags.GetContention(statistics.Flag);
+        logger.LogDebug($"clr_diagnostics_event.contention.startend_count: 1, tags: {tags.Text}");
+        logger.LogDebug($"clr_diagnostics_event.contention.startend_duration_ns: {statistics.DurationNs}, tags: {tags.Text}");
     }
 
     // GCEvent
     public static void GcEventStartEnd(in GCStartEndStatistics statistics, ILogger logger)
     {
-        var key = ZString.Concat("gc_gen:", statistics.Generation, statistics.Type, statistics.Reason);
-        var tags = _tagCache.GetOrAdd(key, (key, stat) => [ZString.Concat($"gc_gen:", stat.Generation), ZString.Concat("gc_type:", stat.Type), ZString.Concat("gc_reason:", stat.GetReasonString())], statistics);
-        logger.LogDebug($"clr_diagnostics_event.gc.startend_count: 1, tags: {TagsToString(tags)}");
-        logger.LogDebug($"clr_diagnostics_event.gc.startend_duration_ms: {statistics.DurationMillsec}, tags: {TagsToString(tags)}");
+        ref readonly var tags = ref MetricTags.GetGcStartEnd(statistics.Generation, statistics.Type, statistics.Reason);
+        logger.LogDebug($"clr_diagnostics_event.gc.startend_count: 1, tags: {tags.Text}");
+        logger.LogDebug($"clr_diagnostics_event.gc.startend_duration_ms: {statistics.DurationMillsec}, tags: {tags.Text}");
     }
 
     public static void GcEventSuspend(in GCSuspendStatistics statistics, ILogger logger)
     {
-        var key = ZString.Concat("gc_suspend:", statistics.Reason);
-        var tags = _tagCache.GetOrAdd(key, (key, stat) => [ZString.Concat("gc_suspend_reason:", stat.GetReasonString())], statistics);
-        logger.LogDebug($"clr_diagnostics_event.gc.suspend_object_count: {statistics.Count}, tags: {TagsToString(tags)}");
-        logger.LogDebug($"clr_diagnostics_event.gc.suspend_duration_ms: {statistics.DurationMillisec}, tags: {TagsToString(tags)}");
+        ref readonly var tags = ref MetricTags.GetGcSuspend(statistics.Reason);
+        logger.LogDebug($"clr_diagnostics_event.gc.suspend_object_count: {statistics.Count}, tags: {tags.Text}");
+        logger.LogDebug($"clr_diagnostics_event.gc.suspend_duration_ms: {statistics.DurationMillisec}, tags: {tags.Text}");
     }
 
     // ThreadPoolEvent
@@ -59,10 +52,9 @@ public static class LoggerTracing
     }
     public static void ThreadPoolEventAdjustment(in ThreadPoolAdjustmentStatistics statistics, ILogger logger)
     {
-        var key = ZString.Concat("thread_adjust_reason", statistics.Reason);
-        var tags = _tagCache.GetOrAdd(key, (key, stat) => [ZString.Concat("thread_adjust_reason:", stat.GetReasonString())], statistics);
-        logger.LogDebug($"clr_diagnostics_event.threadpool.adjustment_avg_throughput: {statistics.AverageThrouput}, tags: {TagsToString(tags)}");
-        logger.LogDebug($"clr_diagnostics_event.threadpool.adjustment_new_workerthreads_count: {statistics.NewWorkerThreads}, tags: {TagsToString(tags)}");
+        ref readonly var tags = ref MetricTags.GetThreadAdjustment(statistics.Reason);
+        logger.LogDebug($"clr_diagnostics_event.threadpool.adjustment_avg_throughput: {statistics.AverageThrouput}, tags: {tags.Text}");
+        logger.LogDebug($"clr_diagnostics_event.threadpool.adjustment_new_workerthreads_count: {statistics.NewWorkerThreads}, tags: {tags.Text}");
     }
     public static void ThreadPoolStarvationEventAdjustment(in ThreadPoolAdjustmentStatistics statistics, ILogger logger)
     {
@@ -99,26 +91,17 @@ public static class LoggerTracing
     // GC
     public static void GcInfoTimerGauge(in GCInfoStatistics statistics, ILogger logger)
     {
-        var baseTagkey = ZString.Concat("gc_mode", statistics.GCMode, statistics.LatencyMode, statistics.CompactionMode);
-        var baseTag = _tagCache.GetOrAdd(baseTagkey, (key, stat) => [
-            ZString.Concat("gc_mode:", stat.GetGCModeString()),
-            ZString.Concat("latency_mode:", stat.GetLatencyModeString()),
-            ZString.Concat("compaction_mode:", stat.GetCompactionModeString())
-        ], statistics);
-        var gen0Tags = _tagCache.GetOrAdd(ZString.Concat("gen0", baseTagkey), key => baseTag.Prepend($"gc_gen:0").ToArray());
-        var gen1Tags = _tagCache.GetOrAdd(ZString.Concat("gen1", baseTagkey), key => baseTag.Prepend($"gc_gen:1").ToArray());
-        var gen2Tags = _tagCache.GetOrAdd(ZString.Concat("gen2", baseTagkey), key => baseTag.Prepend($"gc_gen:2").ToArray());
-        var genLohTags = _tagCache.GetOrAdd(ZString.Concat("genLoh", baseTagkey), key => baseTag.Prepend($"gc_gen:loh").ToArray());
-        logger.LogDebug($"clr_diagnostics_timer.gc.heap_size_bytes: {statistics.HeapSize}, tags: {TagsToString(baseTag)}");
-        logger.LogDebug($"clr_diagnostics_timer.gc.total_allocation_bytes: {statistics.TotalAllocationBytes}, tags: {TagsToString(baseTag)}");
-        logger.LogDebug($"clr_diagnostics_timer.gc.gc_count: {statistics.Gen0Count}, tags: {TagsToString(gen0Tags)}");
-        logger.LogDebug($"clr_diagnostics_timer.gc.gc_count: {statistics.Gen1Count}, tags: {TagsToString(gen1Tags)}");
-        logger.LogDebug($"clr_diagnostics_timer.gc.gc_count: {statistics.Gen2Count}, tags: {TagsToString(gen2Tags)}");
-        logger.LogDebug($"clr_diagnostics_timer.gc.gc_size: {statistics.Gen0Size}, tags: {TagsToString(gen0Tags)}");
-        logger.LogDebug($"clr_diagnostics_timer.gc.gc_size: {statistics.Gen1Size}, tags: {TagsToString(gen1Tags)}");
-        logger.LogDebug($"clr_diagnostics_timer.gc.gc_size: {statistics.Gen2Size}, tags: {TagsToString(gen2Tags)}");
-        logger.LogDebug($"clr_diagnostics_timer.gc.gc_size: {statistics.LohSize}, tags: {TagsToString(genLohTags)}");
-        logger.LogDebug($"clr_diagnostics_timer.gc.time_in_gc_percent: {statistics.TimeInGc}, tags: {TagsToString(baseTag)}");
+        ref readonly var tags = ref MetricTags.GetGcInfo(statistics.GCMode, statistics.LatencyMode, statistics.CompactionMode);
+        logger.LogDebug($"clr_diagnostics_timer.gc.heap_size_bytes: {statistics.HeapSize}, tags: {tags.Base.Text}");
+        logger.LogDebug($"clr_diagnostics_timer.gc.total_allocation_bytes: {statistics.TotalAllocationBytes}, tags: {tags.Base.Text}");
+        logger.LogDebug($"clr_diagnostics_timer.gc.gc_count: {statistics.Gen0Count}, tags: {tags.Gen0.Text}");
+        logger.LogDebug($"clr_diagnostics_timer.gc.gc_count: {statistics.Gen1Count}, tags: {tags.Gen1.Text}");
+        logger.LogDebug($"clr_diagnostics_timer.gc.gc_count: {statistics.Gen2Count}, tags: {tags.Gen2.Text}");
+        logger.LogDebug($"clr_diagnostics_timer.gc.gc_size: {statistics.Gen0Size}, tags: {tags.Gen0.Text}");
+        logger.LogDebug($"clr_diagnostics_timer.gc.gc_size: {statistics.Gen1Size}, tags: {tags.Gen1.Text}");
+        logger.LogDebug($"clr_diagnostics_timer.gc.gc_size: {statistics.Gen2Size}, tags: {tags.Gen2.Text}");
+        logger.LogDebug($"clr_diagnostics_timer.gc.gc_size: {statistics.LohSize}, tags: {tags.Loh.Text}");
+        logger.LogDebug($"clr_diagnostics_timer.gc.time_in_gc_percent: {statistics.TimeInGc}, tags: {tags.Base.Text}");
     }
 
     // Process
@@ -143,6 +126,4 @@ public static class LoggerTracing
         logger.LogDebug($"clr_diagnostics_timer.thread.lock_contention_count: {statistics.LockContentionCount}, tags: ");
         logger.LogDebug($"clr_diagnostics_timer.thread.completed_items_count: {statistics.CompletedItemsCount}, tags: ");
     }
-
-    private static string TagsToString(string[] tags) => string.Join(",", tags);
 }

--- a/src/ClrProfiler.DatadogTracing/LoggerTracing.cs
+++ b/src/ClrProfiler.DatadogTracing/LoggerTracing.cs
@@ -8,34 +8,34 @@ public static partial class LoggerTracing
     public static void ContentionEventStartEnd(in ContentionEventStatistics statistics, ILogger logger)
     {
         ref readonly var tags = ref MetricTags.GetContention(statistics.Flag);
-        LogIntMetric(logger, "clr_diagnostics_event.contention.startend_count", 1, tags.Text);
-        LogDoubleMetric(logger, "clr_diagnostics_event.contention.startend_duration_ns", statistics.DurationNs, tags.Text);
+        LogIntMetric(logger, MetricNames.Event.ContentionStartEndCount, 1, tags.Text);
+        LogDoubleMetric(logger, MetricNames.Event.ContentionStartEndDurationNs, statistics.DurationNs, tags.Text);
     }
 
     public static void GcEventStartEnd(in GCStartEndStatistics statistics, ILogger logger)
     {
         ref readonly var tags = ref MetricTags.GetGcStartEnd(statistics.Generation, statistics.Type, statistics.Reason);
-        LogIntMetric(logger, "clr_diagnostics_event.gc.startend_count", 1, tags.Text);
-        LogDoubleMetric(logger, "clr_diagnostics_event.gc.startend_duration_ms", statistics.DurationMillsec, tags.Text);
+        LogIntMetric(logger, MetricNames.Event.GcStartEndCount, 1, tags.Text);
+        LogDoubleMetric(logger, MetricNames.Event.GcStartEndDurationMs, statistics.DurationMillsec, tags.Text);
     }
 
     public static void GcEventSuspend(in GCSuspendStatistics statistics, ILogger logger)
     {
         ref readonly var tags = ref MetricTags.GetGcSuspend(statistics.Reason);
-        LogUIntMetric(logger, "clr_diagnostics_event.gc.suspend_object_count", statistics.Count, tags.Text);
-        LogDoubleMetric(logger, "clr_diagnostics_event.gc.suspend_duration_ms", statistics.DurationMillisec, tags.Text);
+        LogUIntMetric(logger, MetricNames.Event.GcSuspendObjectCount, statistics.Count, tags.Text);
+        LogDoubleMetric(logger, MetricNames.Event.GcSuspendDurationMs, statistics.DurationMillisec, tags.Text);
     }
 
     public static void ThreadPoolEventWorker(in ThreadPoolWorkerStatistics statistics, ILogger logger)
     {
-        LogUIntMetric(logger, "clr_diagnostics_event.threadpool.available_workerthread_count", statistics.ActiveWrokerThreads, string.Empty);
+        LogUIntMetric(logger, MetricNames.Event.ThreadPoolAvailableWorkerThreadCount, statistics.ActiveWrokerThreads, string.Empty);
     }
 
     public static void ThreadPoolEventAdjustment(in ThreadPoolAdjustmentStatistics statistics, ILogger logger)
     {
         ref readonly var tags = ref MetricTags.GetThreadAdjustment(statistics.Reason);
-        LogDoubleMetric(logger, "clr_diagnostics_event.threadpool.adjustment_avg_throughput", statistics.AverageThrouput, tags.Text);
-        LogUIntMetric(logger, "clr_diagnostics_event.threadpool.adjustment_new_workerthreads_count", statistics.NewWorkerThreads, tags.Text);
+        LogDoubleMetric(logger, MetricNames.Event.ThreadPoolAdjustmentAverageThroughput, statistics.AverageThrouput, tags.Text);
+        LogUIntMetric(logger, MetricNames.Event.ThreadPoolAdjustmentNewWorkerThreadsCount, statistics.NewWorkerThreads, tags.Text);
     }
 
     public static void ThreadPoolStarvationEventAdjustment(in ThreadPoolAdjustmentStatistics statistics, ILogger logger)
@@ -46,37 +46,37 @@ public static partial class LoggerTracing
     public static void GcInfoTimerGauge(in GCInfoStatistics statistics, ILogger logger)
     {
         ref readonly var tags = ref MetricTags.GetGcInfo(statistics.GCMode, statistics.LatencyMode, statistics.CompactionMode);
-        LogLongMetric(logger, "clr_diagnostics_timer.gc.heap_size_bytes", statistics.HeapSize, tags.Base.Text);
-        LogLongMetric(logger, "clr_diagnostics_timer.gc.total_allocation_bytes", statistics.TotalAllocationBytes, tags.Base.Text);
-        LogIntMetric(logger, "clr_diagnostics_timer.gc.gc_count", statistics.Gen0Count, tags.Gen0.Text);
-        LogIntMetric(logger, "clr_diagnostics_timer.gc.gc_count", statistics.Gen1Count, tags.Gen1.Text);
-        LogIntMetric(logger, "clr_diagnostics_timer.gc.gc_count", statistics.Gen2Count, tags.Gen2.Text);
-        LogULongMetric(logger, "clr_diagnostics_timer.gc.gc_size", statistics.Gen0Size, tags.Gen0.Text);
-        LogULongMetric(logger, "clr_diagnostics_timer.gc.gc_size", statistics.Gen1Size, tags.Gen1.Text);
-        LogULongMetric(logger, "clr_diagnostics_timer.gc.gc_size", statistics.Gen2Size, tags.Gen2.Text);
-        LogULongMetric(logger, "clr_diagnostics_timer.gc.gc_size", statistics.LohSize, tags.Loh.Text);
-        LogIntMetric(logger, "clr_diagnostics_timer.gc.time_in_gc_percent", statistics.TimeInGc, tags.Base.Text);
+        LogLongMetric(logger, MetricNames.Timer.GcHeapSizeBytes, statistics.HeapSize, tags.Base.Text);
+        LogLongMetric(logger, MetricNames.Timer.GcTotalAllocationBytes, statistics.TotalAllocationBytes, tags.Base.Text);
+        LogIntMetric(logger, MetricNames.Timer.GcCount, statistics.Gen0Count, tags.Gen0.Text);
+        LogIntMetric(logger, MetricNames.Timer.GcCount, statistics.Gen1Count, tags.Gen1.Text);
+        LogIntMetric(logger, MetricNames.Timer.GcCount, statistics.Gen2Count, tags.Gen2.Text);
+        LogULongMetric(logger, MetricNames.Timer.GcSize, statistics.Gen0Size, tags.Gen0.Text);
+        LogULongMetric(logger, MetricNames.Timer.GcSize, statistics.Gen1Size, tags.Gen1.Text);
+        LogULongMetric(logger, MetricNames.Timer.GcSize, statistics.Gen2Size, tags.Gen2.Text);
+        LogULongMetric(logger, MetricNames.Timer.GcSize, statistics.LohSize, tags.Loh.Text);
+        LogIntMetric(logger, MetricNames.Timer.GcTimeInGcPercent, statistics.TimeInGc, tags.Base.Text);
     }
 
     public static void ProcessInfoTimerGauge(in ProcessInfoStatistics statistics, ILogger logger)
     {
-        LogDoubleMetric(logger, "clr_diagnostics_timer.process.cpu", statistics.Cpu, string.Empty);
-        LogLongMetric(logger, "clr_diagnostics_timer.process.private_bytes", statistics.PrivateBytes, string.Empty);
-        LogLongMetric(logger, "clr_diagnostics_timer.process.working_sets", statistics.WorkingSet, string.Empty);
+        LogDoubleMetric(logger, MetricNames.Timer.ProcessCpu, statistics.Cpu, string.Empty);
+        LogLongMetric(logger, MetricNames.Timer.ProcessPrivateBytes, statistics.PrivateBytes, string.Empty);
+        LogLongMetric(logger, MetricNames.Timer.ProcessWorkingSets, statistics.WorkingSet, string.Empty);
     }
 
     public static void ThreadInfoTimerGauge(in ThreadInfoStatistics statistics, ILogger logger)
     {
-        LogIntMetric(logger, "clr_diagnostics_timer.thread.available_worker_threads", statistics.AvailableWorkerThreads, string.Empty);
-        LogIntMetric(logger, "clr_diagnostics_timer.thread.available_completion_port_threads", statistics.AvailableCompletionPortThreads, string.Empty);
-        LogIntMetric(logger, "clr_diagnostics_timer.thread.max_worker_threads", statistics.MaxWorkerThreads, string.Empty);
-        LogIntMetric(logger, "clr_diagnostics_timer.thread.max_completion_port_threads", statistics.MaxCompletionPortThreads, string.Empty);
-        LogIntMetric(logger, "clr_diagnostics_timer.thread.using_worker_threads", statistics.UsingWorkerThreads, string.Empty);
-        LogIntMetric(logger, "clr_diagnostics_timer.thread.using_completion_port_threads", statistics.UsingCompletionPortThreads, string.Empty);
-        LogIntMetric(logger, "clr_diagnostics_timer.thread.thread_count", statistics.ThreadCount, string.Empty);
-        LogLongMetric(logger, "clr_diagnostics_timer.thread.queue_length", statistics.QueueLength, string.Empty);
-        LogLongMetric(logger, "clr_diagnostics_timer.thread.lock_contention_count", statistics.LockContentionCount, string.Empty);
-        LogLongMetric(logger, "clr_diagnostics_timer.thread.completed_items_count", statistics.CompletedItemsCount, string.Empty);
+        LogIntMetric(logger, MetricNames.Timer.ThreadAvailableWorkerThreads, statistics.AvailableWorkerThreads, string.Empty);
+        LogIntMetric(logger, MetricNames.Timer.ThreadAvailableCompletionPortThreads, statistics.AvailableCompletionPortThreads, string.Empty);
+        LogIntMetric(logger, MetricNames.Timer.ThreadMaxWorkerThreads, statistics.MaxWorkerThreads, string.Empty);
+        LogIntMetric(logger, MetricNames.Timer.ThreadMaxCompletionPortThreads, statistics.MaxCompletionPortThreads, string.Empty);
+        LogIntMetric(logger, MetricNames.Timer.ThreadUsingWorkerThreads, statistics.UsingWorkerThreads, string.Empty);
+        LogIntMetric(logger, MetricNames.Timer.ThreadUsingCompletionPortThreads, statistics.UsingCompletionPortThreads, string.Empty);
+        LogIntMetric(logger, MetricNames.Timer.ThreadCount, statistics.ThreadCount, string.Empty);
+        LogLongMetric(logger, MetricNames.Timer.ThreadQueueLength, statistics.QueueLength, string.Empty);
+        LogLongMetric(logger, MetricNames.Timer.ThreadLockContentionCount, statistics.LockContentionCount, string.Empty);
+        LogLongMetric(logger, MetricNames.Timer.ThreadCompletedItemsCount, statistics.CompletedItemsCount, string.Empty);
     }
 
     [LoggerMessage(Level = LogLevel.Debug, Message = "{MetricName}: {Value}, tags: {Tags}")]

--- a/src/ClrProfiler.DatadogTracing/MetricNames.cs
+++ b/src/ClrProfiler.DatadogTracing/MetricNames.cs
@@ -1,0 +1,162 @@
+namespace ClrProfiler.DatadogTracing;
+
+/// <summary>
+/// Canonical names and tag contracts for every metric emitted by the Datadog and logger adapters.
+/// </summary>
+/// <remarks>
+/// Metric names are constants so using this catalog adds no lookup or allocation to metric hot paths.
+/// Unknown runtime tag values are projected to <c>unknown</c> by <see cref="MetricTags"/>.
+/// </remarks>
+internal static class MetricNames
+{
+    /// <summary>Metrics produced from CLR events.</summary>
+    /// <remarks>
+    /// Tag values:
+    /// <list type="bullet">
+    /// <item><c>contention_type:0|1|unknown</c></item>
+    /// <item><c>gc_gen:0|1|2|unknown</c></item>
+    /// <item><c>gc_type:0|1|2|unknown</c></item>
+    /// <item><c>gc_reason:soh|induced|low_memory|empty|loh|oos_soh|oos_loh|incuded_non_forceblock|stress_testing|finalizer_low_memory_induced|user_gc_request|unknown</c></item>
+    /// <item><c>gc_suspend_reason:other|gc|appdomain_shudown|code_pitch|shutdown|debugger|prep_gc|unknown</c></item>
+    /// <item><c>thread_adjust_reason:warmup|initializing|random_move|climbing_move|change_point|stabilizing|starvation|timedout|cooperative_blocking|unknown</c></item>
+    /// </list>
+    /// </remarks>
+    internal static class Event
+    {
+        /// <summary>Counter. Tags: <c>contention_type:0|1|unknown</c>.</summary>
+        internal const string ContentionStartEndCount = "clr_diagnostics_event.contention.startend_count";
+
+        /// <summary>Gauge in nanoseconds. Tags: <c>contention_type:0|1|unknown</c>.</summary>
+        internal const string ContentionStartEndDurationNs = "clr_diagnostics_event.contention.startend_duration_ns";
+
+        /// <summary>Counter. Tags: <c>gc_gen</c>, <c>gc_type</c>, and <c>gc_reason</c>.</summary>
+        internal const string GcStartEndCount = "clr_diagnostics_event.gc.startend_count";
+
+        /// <summary>Gauge in milliseconds. Tags: <c>gc_gen</c>, <c>gc_type</c>, and <c>gc_reason</c>.</summary>
+        internal const string GcStartEndDurationMs = "clr_diagnostics_event.gc.startend_duration_ms";
+
+        /// <summary>Counter. Tags: <c>gc_suspend_reason</c>.</summary>
+        internal const string GcSuspendObjectCount = "clr_diagnostics_event.gc.suspend_object_count";
+
+        /// <summary>Gauge in milliseconds. Tags: <c>gc_suspend_reason</c>.</summary>
+        internal const string GcSuspendDurationMs = "clr_diagnostics_event.gc.suspend_duration_ms";
+
+        /// <summary>Gauge without metric-specific tags.</summary>
+        internal const string ThreadPoolAvailableWorkerThreadCount = "clr_diagnostics_event.threadpool.available_workerthread_count";
+
+        /// <summary>Gauge. Tags: <c>thread_adjust_reason</c>.</summary>
+        internal const string ThreadPoolAdjustmentAverageThroughput = "clr_diagnostics_event.threadpool.adjustment_avg_throughput";
+
+        /// <summary>Gauge. Tags: <c>thread_adjust_reason</c>.</summary>
+        internal const string ThreadPoolAdjustmentNewWorkerThreadsCount = "clr_diagnostics_event.threadpool.adjustment_new_workerthreads_count";
+
+        private static readonly string[] Values =
+        [
+            ContentionStartEndCount,
+            ContentionStartEndDurationNs,
+            GcStartEndCount,
+            GcStartEndDurationMs,
+            GcSuspendObjectCount,
+            GcSuspendDurationMs,
+            ThreadPoolAvailableWorkerThreadCount,
+            ThreadPoolAdjustmentAverageThroughput,
+            ThreadPoolAdjustmentNewWorkerThreadsCount,
+        ];
+
+        /// <summary>All CLR event metric names in catalog order.</summary>
+        internal static ReadOnlySpan<string> All => Values;
+    }
+
+    /// <summary>Metrics produced by periodic runtime sampling.</summary>
+    /// <remarks>
+    /// GC timer tag values:
+    /// <list type="bullet">
+    /// <item><c>gc_gen:0|1|2|loh</c> on generation-specific metrics</item>
+    /// <item><c>gc_mode:Workstation|Server|unknown</c></item>
+    /// <item><c>latency_mode:Batch|Interactive|LowLatency|SustainedLowLatency|NoGCRegion|unknown</c></item>
+    /// <item><c>compaction_mode:Default|CompactOnce|unknown</c></item>
+    /// </list>
+    /// Process and thread timer metrics have no metric-specific tags.
+    /// </remarks>
+    internal static class Timer
+    {
+        /// <summary>Gauge in bytes. Tags: <c>gc_mode</c>, <c>latency_mode</c>, and <c>compaction_mode</c>.</summary>
+        internal const string GcHeapSizeBytes = "clr_diagnostics_timer.gc.heap_size_bytes";
+
+        /// <summary>Gauge in bytes. Tags: <c>gc_mode</c>, <c>latency_mode</c>, and <c>compaction_mode</c>.</summary>
+        internal const string GcTotalAllocationBytes = "clr_diagnostics_timer.gc.total_allocation_bytes";
+
+        /// <summary>Gauge. Tags: <c>gc_gen:0|1|2</c> plus the GC mode tags.</summary>
+        internal const string GcCount = "clr_diagnostics_timer.gc.gc_count";
+
+        /// <summary>Gauge in bytes. Tags: <c>gc_gen:0|1|2|loh</c> plus the GC mode tags.</summary>
+        internal const string GcSize = "clr_diagnostics_timer.gc.gc_size";
+
+        /// <summary>Gauge as a percentage. Tags: <c>gc_mode</c>, <c>latency_mode</c>, and <c>compaction_mode</c>.</summary>
+        internal const string GcTimeInGcPercent = "clr_diagnostics_timer.gc.time_in_gc_percent";
+
+        /// <summary>Gauge without metric-specific tags.</summary>
+        internal const string ProcessCpu = "clr_diagnostics_timer.process.cpu";
+
+        /// <summary>Gauge in bytes without metric-specific tags.</summary>
+        internal const string ProcessPrivateBytes = "clr_diagnostics_timer.process.private_bytes";
+
+        /// <summary>Gauge in bytes without metric-specific tags.</summary>
+        internal const string ProcessWorkingSets = "clr_diagnostics_timer.process.working_sets";
+
+        /// <summary>Gauge without metric-specific tags.</summary>
+        internal const string ThreadAvailableWorkerThreads = "clr_diagnostics_timer.thread.available_worker_threads";
+
+        /// <summary>Gauge without metric-specific tags.</summary>
+        internal const string ThreadAvailableCompletionPortThreads = "clr_diagnostics_timer.thread.available_completion_port_threads";
+
+        /// <summary>Gauge without metric-specific tags.</summary>
+        internal const string ThreadMaxWorkerThreads = "clr_diagnostics_timer.thread.max_worker_threads";
+
+        /// <summary>Gauge without metric-specific tags.</summary>
+        internal const string ThreadMaxCompletionPortThreads = "clr_diagnostics_timer.thread.max_completion_port_threads";
+
+        /// <summary>Gauge without metric-specific tags.</summary>
+        internal const string ThreadUsingWorkerThreads = "clr_diagnostics_timer.thread.using_worker_threads";
+
+        /// <summary>Gauge without metric-specific tags.</summary>
+        internal const string ThreadUsingCompletionPortThreads = "clr_diagnostics_timer.thread.using_completion_port_threads";
+
+        /// <summary>Gauge without metric-specific tags.</summary>
+        internal const string ThreadCount = "clr_diagnostics_timer.thread.thread_count";
+
+        /// <summary>Gauge without metric-specific tags.</summary>
+        internal const string ThreadQueueLength = "clr_diagnostics_timer.thread.queue_length";
+
+        /// <summary>Gauge without metric-specific tags.</summary>
+        internal const string ThreadLockContentionCount = "clr_diagnostics_timer.thread.lock_contention_count";
+
+        /// <summary>Gauge without metric-specific tags.</summary>
+        internal const string ThreadCompletedItemsCount = "clr_diagnostics_timer.thread.completed_items_count";
+
+        private static readonly string[] Values =
+        [
+            GcHeapSizeBytes,
+            GcTotalAllocationBytes,
+            GcCount,
+            GcSize,
+            GcTimeInGcPercent,
+            ProcessCpu,
+            ProcessPrivateBytes,
+            ProcessWorkingSets,
+            ThreadAvailableWorkerThreads,
+            ThreadAvailableCompletionPortThreads,
+            ThreadMaxWorkerThreads,
+            ThreadMaxCompletionPortThreads,
+            ThreadUsingWorkerThreads,
+            ThreadUsingCompletionPortThreads,
+            ThreadCount,
+            ThreadQueueLength,
+            ThreadLockContentionCount,
+            ThreadCompletedItemsCount,
+        ];
+
+        /// <summary>All timer metric names in catalog order.</summary>
+        internal static ReadOnlySpan<string> All => Values;
+    }
+}

--- a/src/ClrProfiler.DatadogTracing/MetricTags.cs
+++ b/src/ClrProfiler.DatadogTracing/MetricTags.cs
@@ -1,0 +1,236 @@
+using ClrProfiler.Statistics;
+using System.Runtime;
+
+namespace ClrProfiler.DatadogTracing;
+
+internal readonly struct MetricTagSet
+{
+    public readonly string[] Values;
+    public readonly string Text;
+
+    public MetricTagSet(string[] values)
+    {
+        Values = values;
+        Text = string.Join(',', values);
+    }
+}
+
+internal readonly struct GcInfoMetricTagSet
+{
+    public readonly MetricTagSet Base;
+    public readonly MetricTagSet Gen0;
+    public readonly MetricTagSet Gen1;
+    public readonly MetricTagSet Gen2;
+    public readonly MetricTagSet Loh;
+
+    public GcInfoMetricTagSet(MetricTagSet @base)
+    {
+        Base = @base;
+        Gen0 = WithGeneration("gc_gen:0", @base.Values);
+        Gen1 = WithGeneration("gc_gen:1", @base.Values);
+        Gen2 = WithGeneration("gc_gen:2", @base.Values);
+        Loh = WithGeneration("gc_gen:loh", @base.Values);
+    }
+
+    private static MetricTagSet WithGeneration(string generation, string[] baseTags)
+    {
+        return new MetricTagSet([generation, baseTags[0], baseTags[1], baseTags[2]]);
+    }
+}
+
+internal static class MetricTags
+{
+    private const int GcGenerationCount = 3;
+    private const int GcTypeCount = 3;
+    private const int GcReasonCount = 11;
+    private const int GcModeCount = 2;
+    private const int GcLatencyModeCount = 5;
+    private const int GcCompactionModeCount = 2;
+
+    private static readonly string[] GcReasonNames =
+    [
+        "soh",
+        "induced",
+        "low_memory",
+        "empty",
+        "loh",
+        "oos_soh",
+        "oos_loh",
+        "incuded_non_forceblock",
+        "stress_testing",
+        "finalizer_low_memory_induced",
+        "user_gc_request",
+    ];
+
+    private static readonly string[] GcSuspendReasonNames =
+    [
+        "other",
+        "gc",
+        "appdomain_shudown",
+        "code_pitch",
+        "shutdown",
+        "debugger",
+        "prep_gc",
+    ];
+
+    private static readonly string[] ThreadAdjustmentReasonNames =
+    [
+        "warmup",
+        "initializing",
+        "random_move",
+        "climbing_move",
+        "change_point",
+        "stabilizing",
+        "starvation",
+        "timedout",
+        "cooperative_blocking",
+    ];
+
+    private static readonly MetricTagSet[] ContentionTags = CreateSingleValueTags("contention_type:", 2);
+    private static readonly MetricTagSet[] GcStartEndTags = CreateGcStartEndTags();
+    private static readonly MetricTagSet[] GcSuspendTags = CreateNamedTags("gc_suspend_reason:", GcSuspendReasonNames);
+    private static readonly MetricTagSet[] ThreadAdjustmentTags = CreateNamedTags("thread_adjust_reason:", ThreadAdjustmentReasonNames);
+    private static readonly GcInfoMetricTagSet[] GcInfoTags = CreateGcInfoTags();
+
+    public static ref readonly MetricTagSet GetContention(byte flag)
+    {
+        if (flag >= ContentionTags.Length)
+        {
+            throw new ArgumentOutOfRangeException(nameof(flag), flag, "Contention flag is not defined.");
+        }
+
+        return ref ContentionTags[flag];
+    }
+
+    public static ref readonly MetricTagSet GetGcStartEnd(uint generation, uint type, uint reason)
+    {
+        if (generation >= GcGenerationCount)
+        {
+            throw new ArgumentOutOfRangeException(nameof(generation), generation, "GC generation is not defined.");
+        }
+        if (type >= GcTypeCount)
+        {
+            throw new ArgumentOutOfRangeException(nameof(type), type, "GC type is not defined.");
+        }
+        if (reason >= GcReasonCount)
+        {
+            throw new ArgumentOutOfRangeException(nameof(reason), reason, "GC reason is not defined.");
+        }
+
+        var index = ((int)generation * GcTypeCount * GcReasonCount) + ((int)type * GcReasonCount) + (int)reason;
+        return ref GcStartEndTags[index];
+    }
+
+    public static ref readonly MetricTagSet GetGcSuspend(uint reason)
+    {
+        if (reason >= GcSuspendTags.Length)
+        {
+            throw new ArgumentOutOfRangeException(nameof(reason), reason, "GC suspend reason is not defined.");
+        }
+
+        return ref GcSuspendTags[reason];
+    }
+
+    public static ref readonly MetricTagSet GetThreadAdjustment(uint reason)
+    {
+        if (reason >= ThreadAdjustmentTags.Length)
+        {
+            throw new ArgumentOutOfRangeException(nameof(reason), reason, "Thread adjustment reason is not defined.");
+        }
+
+        return ref ThreadAdjustmentTags[reason];
+    }
+
+    public static ref readonly GcInfoMetricTagSet GetGcInfo(GCMode mode, GCLatencyMode latencyMode, GCLargeObjectHeapCompactionMode compactionMode)
+    {
+        var modeIndex = mode switch
+        {
+            GCMode.Workstation => 0,
+            GCMode.Server => 1,
+            _ => throw new ArgumentOutOfRangeException(nameof(mode), mode, "GC mode is not defined."),
+        };
+        var latencyIndex = latencyMode switch
+        {
+            GCLatencyMode.Batch => 0,
+            GCLatencyMode.Interactive => 1,
+            GCLatencyMode.LowLatency => 2,
+            GCLatencyMode.SustainedLowLatency => 3,
+            GCLatencyMode.NoGCRegion => 4,
+            _ => throw new ArgumentOutOfRangeException(nameof(latencyMode), latencyMode, "GC latency mode is not defined."),
+        };
+        var compactionIndex = compactionMode switch
+        {
+            GCLargeObjectHeapCompactionMode.Default => 0,
+            GCLargeObjectHeapCompactionMode.CompactOnce => 1,
+            _ => throw new ArgumentOutOfRangeException(nameof(compactionMode), compactionMode, "GC compaction mode is not defined."),
+        };
+
+        var index = (modeIndex * GcLatencyModeCount * GcCompactionModeCount) + (latencyIndex * GcCompactionModeCount) + compactionIndex;
+        return ref GcInfoTags[index];
+    }
+
+    private static MetricTagSet[] CreateSingleValueTags(string prefix, int count)
+    {
+        var tags = new MetricTagSet[count];
+        for (var i = 0; i < tags.Length; i++)
+        {
+            tags[i] = new MetricTagSet([$"{prefix}{i}"]);
+        }
+        return tags;
+    }
+
+    private static MetricTagSet[] CreateNamedTags(string prefix, string[] names)
+    {
+        var tags = new MetricTagSet[names.Length];
+        for (var i = 0; i < tags.Length; i++)
+        {
+            tags[i] = new MetricTagSet([$"{prefix}{names[i]}"]);
+        }
+        return tags;
+    }
+
+    private static MetricTagSet[] CreateGcStartEndTags()
+    {
+        var tags = new MetricTagSet[GcGenerationCount * GcTypeCount * GcReasonCount];
+        for (var generation = 0; generation < GcGenerationCount; generation++)
+        {
+            for (var type = 0; type < GcTypeCount; type++)
+            {
+                for (var reason = 0; reason < GcReasonCount; reason++)
+                {
+                    var index = (generation * GcTypeCount * GcReasonCount) + (type * GcReasonCount) + reason;
+                    tags[index] = new MetricTagSet([$"gc_gen:{generation}", $"gc_type:{type}", $"gc_reason:{GcReasonNames[reason]}"]);
+                }
+            }
+        }
+        return tags;
+    }
+
+    private static GcInfoMetricTagSet[] CreateGcInfoTags()
+    {
+        var modeNames = new[] { "Workstation", "Server" };
+        var latencyNames = new[] { "Batch", "Interactive", "LowLatency", "SustainedLowLatency", "NoGCRegion" };
+        var compactionNames = new[] { "Default", "CompactOnce" };
+        var tags = new GcInfoMetricTagSet[GcModeCount * GcLatencyModeCount * GcCompactionModeCount];
+
+        for (var mode = 0; mode < GcModeCount; mode++)
+        {
+            for (var latency = 0; latency < GcLatencyModeCount; latency++)
+            {
+                for (var compaction = 0; compaction < GcCompactionModeCount; compaction++)
+                {
+                    var index = (mode * GcLatencyModeCount * GcCompactionModeCount) + (latency * GcCompactionModeCount) + compaction;
+                    var baseTags = new MetricTagSet(
+                    [
+                        $"gc_mode:{modeNames[mode]}",
+                        $"latency_mode:{latencyNames[latency]}",
+                        $"compaction_mode:{compactionNames[compaction]}",
+                    ]);
+                    tags[index] = new GcInfoMetricTagSet(baseTags);
+                }
+            }
+        }
+
+        return tags;
+    }
+}

--- a/src/ClrProfiler.DatadogTracing/MetricTags.cs
+++ b/src/ClrProfiler.DatadogTracing/MetricTags.cs
@@ -23,13 +23,13 @@ internal readonly struct GcInfoMetricTagSet
     public readonly MetricTagSet Gen2;
     public readonly MetricTagSet Loh;
 
-    public GcInfoMetricTagSet(MetricTagSet @base)
+    public GcInfoMetricTagSet(MetricTagSet @base, string gen0, string gen1, string gen2, string loh)
     {
         Base = @base;
-        Gen0 = WithGeneration("gc_gen:0", @base.Values);
-        Gen1 = WithGeneration("gc_gen:1", @base.Values);
-        Gen2 = WithGeneration("gc_gen:2", @base.Values);
-        Loh = WithGeneration("gc_gen:loh", @base.Values);
+        Gen0 = WithGeneration(gen0, @base.Values);
+        Gen1 = WithGeneration(gen1, @base.Values);
+        Gen2 = WithGeneration(gen2, @base.Values);
+        Loh = WithGeneration(loh, @base.Values);
     }
 
     private static MetricTagSet WithGeneration(string generation, string[] baseTags)
@@ -40,105 +40,75 @@ internal readonly struct GcInfoMetricTagSet
 
 internal static class MetricTags
 {
-    private const int GcGenerationCount = 3;
-    private const int GcTypeCount = 3;
-    private const int GcReasonCount = 11;
-    private const int GcModeCount = 2;
-    private const int GcLatencyModeCount = 5;
-    private const int GcCompactionModeCount = 2;
+    private const int KnownContentionFlagCount = 2;
+    private const int KnownGcGenerationCount = 3;
+    private const int KnownGcTypeCount = 3;
+    private const int KnownGcReasonCount = 11;
+    private const int KnownGcModeCount = 2;
+    private const int KnownGcLatencyModeCount = 5;
+    private const int KnownGcCompactionModeCount = 2;
+    private const int KnownGcSuspendReasonCount = 7;
+    private const int KnownThreadAdjustmentReasonCount = 9;
 
-    private static readonly string[] GcReasonNames =
-    [
-        "soh",
-        "induced",
-        "low_memory",
-        "empty",
-        "loh",
-        "oos_soh",
-        "oos_loh",
-        "incuded_non_forceblock",
-        "stress_testing",
-        "finalizer_low_memory_induced",
-        "user_gc_request",
-    ];
+    private const int ContentionFlagCount = KnownContentionFlagCount + 1;
+    private const int GcGenerationCount = KnownGcGenerationCount + 1;
+    private const int GcTypeCount = KnownGcTypeCount + 1;
+    private const int GcReasonCount = KnownGcReasonCount + 1;
+    private const int GcModeCount = KnownGcModeCount + 1;
+    private const int GcLatencyModeCount = KnownGcLatencyModeCount + 1;
+    private const int GcCompactionModeCount = KnownGcCompactionModeCount + 1;
 
-    private static readonly string[] GcSuspendReasonNames =
-    [
-        "other",
-        "gc",
-        "appdomain_shudown",
-        "code_pitch",
-        "shutdown",
-        "debugger",
-        "prep_gc",
-    ];
+    private static readonly string[] ContentionTagValues = CreateNumericTagValues("contention_type:", KnownContentionFlagCount);
+    private static readonly string[] GcGenerationTagValues = CreateNumericTagValues("gc_gen:", KnownGcGenerationCount);
+    private static readonly string[] GcTypeTagValues = CreateNumericTagValues("gc_type:", KnownGcTypeCount);
+    private static readonly string[] GcReasonTagValues = CreateGcReasonTagValues();
+    private static readonly string[] GcSuspendTagValues = CreateGcSuspendTagValues();
+    private static readonly string[] ThreadAdjustmentTagValues = CreateThreadAdjustmentTagValues();
+    private static readonly string[] GcModeTagValues = CreateGcModeTagValues();
+    private static readonly string[] GcLatencyModeTagValues = CreateGcLatencyModeTagValues();
+    private static readonly string[] GcCompactionModeTagValues = CreateGcCompactionModeTagValues();
 
-    private static readonly string[] ThreadAdjustmentReasonNames =
-    [
-        "warmup",
-        "initializing",
-        "random_move",
-        "climbing_move",
-        "change_point",
-        "stabilizing",
-        "starvation",
-        "timedout",
-        "cooperative_blocking",
-    ];
-
-    private static readonly MetricTagSet[] ContentionTags = CreateSingleValueTags("contention_type:", 2);
+    private static readonly MetricTagSet[] ContentionTags = CreateSingleValueTagSets(ContentionTagValues);
     private static readonly MetricTagSet[] GcStartEndTags = CreateGcStartEndTags();
-    private static readonly MetricTagSet[] GcSuspendTags = CreateNamedTags("gc_suspend_reason:", GcSuspendReasonNames);
-    private static readonly MetricTagSet[] ThreadAdjustmentTags = CreateNamedTags("thread_adjust_reason:", ThreadAdjustmentReasonNames);
+    private static readonly MetricTagSet[] GcSuspendTags = CreateSingleValueTagSets(GcSuspendTagValues);
+    private static readonly MetricTagSet[] ThreadAdjustmentTags = CreateSingleValueTagSets(ThreadAdjustmentTagValues);
     private static readonly GcInfoMetricTagSet[] GcInfoTags = CreateGcInfoTags();
+
+    static MetricTags()
+    {
+    }
+
+    public static void Initialize()
+    {
+        // The explicit static constructor guarantees initialization before this method runs.
+        GC.KeepAlive(GcInfoTags);
+    }
 
     public static ref readonly MetricTagSet GetContention(byte flag)
     {
-        if (flag >= ContentionTags.Length)
-        {
-            throw new ArgumentOutOfRangeException(nameof(flag), flag, "Contention flag is not defined.");
-        }
-
-        return ref ContentionTags[flag];
+        var index = flag < KnownContentionFlagCount ? flag : KnownContentionFlagCount;
+        return ref ContentionTags[index];
     }
 
     public static ref readonly MetricTagSet GetGcStartEnd(uint generation, uint type, uint reason)
     {
-        if (generation >= GcGenerationCount)
-        {
-            throw new ArgumentOutOfRangeException(nameof(generation), generation, "GC generation is not defined.");
-        }
-        if (type >= GcTypeCount)
-        {
-            throw new ArgumentOutOfRangeException(nameof(type), type, "GC type is not defined.");
-        }
-        if (reason >= GcReasonCount)
-        {
-            throw new ArgumentOutOfRangeException(nameof(reason), reason, "GC reason is not defined.");
-        }
-
-        var index = ((int)generation * GcTypeCount * GcReasonCount) + ((int)type * GcReasonCount) + (int)reason;
+        var generationIndex = generation < KnownGcGenerationCount ? (int)generation : KnownGcGenerationCount;
+        var typeIndex = type < KnownGcTypeCount ? (int)type : KnownGcTypeCount;
+        var reasonIndex = reason < KnownGcReasonCount ? (int)reason : KnownGcReasonCount;
+        var index = (generationIndex * GcTypeCount * GcReasonCount) + (typeIndex * GcReasonCount) + reasonIndex;
         return ref GcStartEndTags[index];
     }
 
     public static ref readonly MetricTagSet GetGcSuspend(uint reason)
     {
-        if (reason >= GcSuspendTags.Length)
-        {
-            throw new ArgumentOutOfRangeException(nameof(reason), reason, "GC suspend reason is not defined.");
-        }
-
-        return ref GcSuspendTags[reason];
+        var index = reason < KnownGcSuspendReasonCount ? (int)reason : KnownGcSuspendReasonCount;
+        return ref GcSuspendTags[index];
     }
 
     public static ref readonly MetricTagSet GetThreadAdjustment(uint reason)
     {
-        if (reason >= ThreadAdjustmentTags.Length)
-        {
-            throw new ArgumentOutOfRangeException(nameof(reason), reason, "Thread adjustment reason is not defined.");
-        }
-
-        return ref ThreadAdjustmentTags[reason];
+        var index = reason < KnownThreadAdjustmentReasonCount ? (int)reason : KnownThreadAdjustmentReasonCount;
+        return ref ThreadAdjustmentTags[index];
     }
 
     public static ref readonly GcInfoMetricTagSet GetGcInfo(GCMode mode, GCLatencyMode latencyMode, GCLargeObjectHeapCompactionMode compactionMode)
@@ -147,7 +117,7 @@ internal static class MetricTags
         {
             GCMode.Workstation => 0,
             GCMode.Server => 1,
-            _ => throw new ArgumentOutOfRangeException(nameof(mode), mode, "GC mode is not defined."),
+            _ => KnownGcModeCount,
         };
         var latencyIndex = latencyMode switch
         {
@@ -156,35 +126,110 @@ internal static class MetricTags
             GCLatencyMode.LowLatency => 2,
             GCLatencyMode.SustainedLowLatency => 3,
             GCLatencyMode.NoGCRegion => 4,
-            _ => throw new ArgumentOutOfRangeException(nameof(latencyMode), latencyMode, "GC latency mode is not defined."),
+            _ => KnownGcLatencyModeCount,
         };
         var compactionIndex = compactionMode switch
         {
             GCLargeObjectHeapCompactionMode.Default => 0,
             GCLargeObjectHeapCompactionMode.CompactOnce => 1,
-            _ => throw new ArgumentOutOfRangeException(nameof(compactionMode), compactionMode, "GC compaction mode is not defined."),
+            _ => KnownGcCompactionModeCount,
         };
 
         var index = (modeIndex * GcLatencyModeCount * GcCompactionModeCount) + (latencyIndex * GcCompactionModeCount) + compactionIndex;
         return ref GcInfoTags[index];
     }
 
-    private static MetricTagSet[] CreateSingleValueTags(string prefix, int count)
+    private static string[] CreateNumericTagValues(string prefix, int knownCount)
     {
-        var tags = new MetricTagSet[count];
-        for (var i = 0; i < tags.Length; i++)
+        var values = new string[knownCount + 1];
+        for (var i = 0; i < knownCount; i++)
         {
-            tags[i] = new MetricTagSet([$"{prefix}{i}"]);
+            values[i] = $"{prefix}{i}";
         }
-        return tags;
+        values[knownCount] = $"{prefix}unknown";
+        return values;
     }
 
-    private static MetricTagSet[] CreateNamedTags(string prefix, string[] names)
+    private static string[] CreateGcReasonTagValues()
     {
-        var tags = new MetricTagSet[names.Length];
+        var values = new string[KnownGcReasonCount + 1];
+        for (var reason = 0; reason < KnownGcReasonCount; reason++)
+        {
+            var statistics = new GCStartEndStatistics(0, 0, 0, (uint)reason, 0, 0, 0);
+            values[reason] = $"gc_reason:{statistics.GetReasonString()}";
+        }
+        values[KnownGcReasonCount] = "gc_reason:unknown";
+        return values;
+    }
+
+    private static string[] CreateGcSuspendTagValues()
+    {
+        var values = new string[KnownGcSuspendReasonCount + 1];
+        for (var reason = 0; reason < KnownGcSuspendReasonCount; reason++)
+        {
+            var statistics = new GCSuspendStatistics(0, (uint)reason, 0);
+            values[reason] = $"gc_suspend_reason:{statistics.GetReasonString()}";
+        }
+        values[KnownGcSuspendReasonCount] = "gc_suspend_reason:unknown";
+        return values;
+    }
+
+    private static string[] CreateThreadAdjustmentTagValues()
+    {
+        var values = new string[KnownThreadAdjustmentReasonCount + 1];
+        for (var reason = 0; reason < KnownThreadAdjustmentReasonCount; reason++)
+        {
+            var statistics = new ThreadPoolAdjustmentStatistics(0, 0, 0, (uint)reason);
+            values[reason] = $"thread_adjust_reason:{statistics.GetReasonString()}";
+        }
+        values[KnownThreadAdjustmentReasonCount] = "thread_adjust_reason:unknown";
+        return values;
+    }
+
+    private static string[] CreateGcModeTagValues()
+    {
+        return
+        [
+            $"gc_mode:{CreateGcInfo(GCMode.Workstation, GCLatencyMode.Interactive, GCLargeObjectHeapCompactionMode.Default).GetGCModeString()}",
+            $"gc_mode:{CreateGcInfo(GCMode.Server, GCLatencyMode.Interactive, GCLargeObjectHeapCompactionMode.Default).GetGCModeString()}",
+            "gc_mode:unknown",
+        ];
+    }
+
+    private static string[] CreateGcLatencyModeTagValues()
+    {
+        return
+        [
+            $"latency_mode:{CreateGcInfo(GCMode.Workstation, GCLatencyMode.Batch, GCLargeObjectHeapCompactionMode.Default).GetLatencyModeString()}",
+            $"latency_mode:{CreateGcInfo(GCMode.Workstation, GCLatencyMode.Interactive, GCLargeObjectHeapCompactionMode.Default).GetLatencyModeString()}",
+            $"latency_mode:{CreateGcInfo(GCMode.Workstation, GCLatencyMode.LowLatency, GCLargeObjectHeapCompactionMode.Default).GetLatencyModeString()}",
+            $"latency_mode:{CreateGcInfo(GCMode.Workstation, GCLatencyMode.SustainedLowLatency, GCLargeObjectHeapCompactionMode.Default).GetLatencyModeString()}",
+            $"latency_mode:{CreateGcInfo(GCMode.Workstation, GCLatencyMode.NoGCRegion, GCLargeObjectHeapCompactionMode.Default).GetLatencyModeString()}",
+            "latency_mode:unknown",
+        ];
+    }
+
+    private static string[] CreateGcCompactionModeTagValues()
+    {
+        return
+        [
+            $"compaction_mode:{CreateGcInfo(GCMode.Workstation, GCLatencyMode.Interactive, GCLargeObjectHeapCompactionMode.Default).GetCompactionModeString()}",
+            $"compaction_mode:{CreateGcInfo(GCMode.Workstation, GCLatencyMode.Interactive, GCLargeObjectHeapCompactionMode.CompactOnce).GetCompactionModeString()}",
+            "compaction_mode:unknown",
+        ];
+    }
+
+    private static GCInfoStatistics CreateGcInfo(GCMode mode, GCLatencyMode latencyMode, GCLargeObjectHeapCompactionMode compactionMode)
+    {
+        return new GCInfoStatistics(default, mode, compactionMode, latencyMode, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0);
+    }
+
+    private static MetricTagSet[] CreateSingleValueTagSets(string[] values)
+    {
+        var tags = new MetricTagSet[values.Length];
         for (var i = 0; i < tags.Length; i++)
         {
-            tags[i] = new MetricTagSet([$"{prefix}{names[i]}"]);
+            tags[i] = new MetricTagSet([values[i]]);
         }
         return tags;
     }
@@ -199,7 +244,7 @@ internal static class MetricTags
                 for (var reason = 0; reason < GcReasonCount; reason++)
                 {
                     var index = (generation * GcTypeCount * GcReasonCount) + (type * GcReasonCount) + reason;
-                    tags[index] = new MetricTagSet([$"gc_gen:{generation}", $"gc_type:{type}", $"gc_reason:{GcReasonNames[reason]}"]);
+                    tags[index] = new MetricTagSet([GcGenerationTagValues[generation], GcTypeTagValues[type], GcReasonTagValues[reason]]);
                 }
             }
         }
@@ -208,11 +253,7 @@ internal static class MetricTags
 
     private static GcInfoMetricTagSet[] CreateGcInfoTags()
     {
-        var modeNames = new[] { "Workstation", "Server" };
-        var latencyNames = new[] { "Batch", "Interactive", "LowLatency", "SustainedLowLatency", "NoGCRegion" };
-        var compactionNames = new[] { "Default", "CompactOnce" };
         var tags = new GcInfoMetricTagSet[GcModeCount * GcLatencyModeCount * GcCompactionModeCount];
-
         for (var mode = 0; mode < GcModeCount; mode++)
         {
             for (var latency = 0; latency < GcLatencyModeCount; latency++)
@@ -220,17 +261,16 @@ internal static class MetricTags
                 for (var compaction = 0; compaction < GcCompactionModeCount; compaction++)
                 {
                     var index = (mode * GcLatencyModeCount * GcCompactionModeCount) + (latency * GcCompactionModeCount) + compaction;
-                    var baseTags = new MetricTagSet(
-                    [
-                        $"gc_mode:{modeNames[mode]}",
-                        $"latency_mode:{latencyNames[latency]}",
-                        $"compaction_mode:{compactionNames[compaction]}",
-                    ]);
-                    tags[index] = new GcInfoMetricTagSet(baseTags);
+                    var baseTags = new MetricTagSet([GcModeTagValues[mode], GcLatencyModeTagValues[latency], GcCompactionModeTagValues[compaction]]);
+                    tags[index] = new GcInfoMetricTagSet(
+                        baseTags,
+                        GcGenerationTagValues[0],
+                        GcGenerationTagValues[1],
+                        GcGenerationTagValues[2],
+                        "gc_gen:loh");
                 }
             }
         }
-
         return tags;
     }
 }

--- a/tests/CleProfiler.DatadogTracing.UnitTest/ClrTrackerMetricTagsInitializationTest.cs
+++ b/tests/CleProfiler.DatadogTracing.UnitTest/ClrTrackerMetricTagsInitializationTest.cs
@@ -1,0 +1,25 @@
+using ClrProfiler.DatadogTracing;
+
+namespace CleProfiler.DatadogTracing.UnitTest;
+
+[NotInParallel]
+public class ClrTrackerMetricTagsInitializationTest
+{
+    [Test]
+    [Arguments(ClrTrackerType.Datadog)]
+    [Arguments(ClrTrackerType.Logger)]
+    public async Task EnableTracker_PrewarmsMetricTagsExactlyOnce(ClrTrackerType trackerType)
+    {
+        using var loggerFactory = TestHelpers.CreateLoggerFactory();
+        var initializationCount = 0;
+        using var tracker = new ClrTracker(
+            loggerFactory,
+            new ClrTrackerOptions { TrackerType = trackerType },
+            () => initializationCount++);
+
+        tracker.EnableTracker();
+        tracker.EnableTracker();
+
+        await Assert.That(initializationCount).IsEqualTo(1);
+    }
+}

--- a/tests/CleProfiler.DatadogTracing.UnitTest/DatadogTracingUnitTest.cs
+++ b/tests/CleProfiler.DatadogTracing.UnitTest/DatadogTracingUnitTest.cs
@@ -65,6 +65,8 @@ public class DatadogTracingUnitTest
         }
         await Assert.That(list).Contains(x => x.Contains("clr_diagnostics_event.gc.suspend_object_count"));
         await Assert.That(list).Contains(x => x.Contains("clr_diagnostics_event.gc.suspend_duration_ms"));
+        await Assert.That(list).Contains(x => x.Contains("gc_gen:2,gc_type:0,gc_reason:induced"));
+        await Assert.That(list).Contains(x => x.Contains("gc_suspend_reason:gc"));
 
         tracker.StopTracker();
         cts.Cancel();

--- a/tests/CleProfiler.DatadogTracing.UnitTest/MetricNamesTest.cs
+++ b/tests/CleProfiler.DatadogTracing.UnitTest/MetricNamesTest.cs
@@ -1,0 +1,51 @@
+using ClrProfiler.DatadogTracing;
+
+namespace CleProfiler.DatadogTracing.UnitTest;
+
+public class MetricNamesTest
+{
+    [Test]
+    public async Task EventCatalog_ContainsEveryEmittedMetricOnce()
+    {
+        var actual = string.Join('\n', MetricNames.Event.All.ToArray());
+
+        await Assert.That(actual).IsEqualTo("""
+            clr_diagnostics_event.contention.startend_count
+            clr_diagnostics_event.contention.startend_duration_ns
+            clr_diagnostics_event.gc.startend_count
+            clr_diagnostics_event.gc.startend_duration_ms
+            clr_diagnostics_event.gc.suspend_object_count
+            clr_diagnostics_event.gc.suspend_duration_ms
+            clr_diagnostics_event.threadpool.available_workerthread_count
+            clr_diagnostics_event.threadpool.adjustment_avg_throughput
+            clr_diagnostics_event.threadpool.adjustment_new_workerthreads_count
+            """);
+    }
+
+    [Test]
+    public async Task TimerCatalog_ContainsEveryEmittedMetricOnce()
+    {
+        var actual = string.Join('\n', MetricNames.Timer.All.ToArray());
+
+        await Assert.That(actual).IsEqualTo("""
+            clr_diagnostics_timer.gc.heap_size_bytes
+            clr_diagnostics_timer.gc.total_allocation_bytes
+            clr_diagnostics_timer.gc.gc_count
+            clr_diagnostics_timer.gc.gc_size
+            clr_diagnostics_timer.gc.time_in_gc_percent
+            clr_diagnostics_timer.process.cpu
+            clr_diagnostics_timer.process.private_bytes
+            clr_diagnostics_timer.process.working_sets
+            clr_diagnostics_timer.thread.available_worker_threads
+            clr_diagnostics_timer.thread.available_completion_port_threads
+            clr_diagnostics_timer.thread.max_worker_threads
+            clr_diagnostics_timer.thread.max_completion_port_threads
+            clr_diagnostics_timer.thread.using_worker_threads
+            clr_diagnostics_timer.thread.using_completion_port_threads
+            clr_diagnostics_timer.thread.thread_count
+            clr_diagnostics_timer.thread.queue_length
+            clr_diagnostics_timer.thread.lock_contention_count
+            clr_diagnostics_timer.thread.completed_items_count
+            """);
+    }
+}

--- a/tests/CleProfiler.DatadogTracing.UnitTest/MetricTagAllocationTest.cs
+++ b/tests/CleProfiler.DatadogTracing.UnitTest/MetricTagAllocationTest.cs
@@ -11,7 +11,7 @@ public class MetricTagAllocationTest
     private static readonly GCStartEndStatistics Statistics = new(1, 0, 2, 1, 1.5, 100, 200);
 
     [Test]
-    public async Task LoggerGcEventStartEnd_ReusesPrecomputedTags()
+    public async Task LoggerGcEventStartEnd_WhenDebugDisabled_DoesNotAllocate()
     {
         for (var i = 0; i < 1_000; i++)
         {
@@ -26,7 +26,7 @@ public class MetricTagAllocationTest
         var allocatedBytes = GC.GetAllocatedBytesForCurrentThread() - before;
 
         Console.WriteLine($"Allocated bytes: {allocatedBytes}; bytes/call: {(double)allocatedBytes / Iterations:N2}");
-        await Assert.That(allocatedBytes).IsLessThanOrEqualTo(480L * Iterations);
+        await Assert.That(allocatedBytes).IsEqualTo(0);
     }
 
     [Test]

--- a/tests/CleProfiler.DatadogTracing.UnitTest/MetricTagAllocationTest.cs
+++ b/tests/CleProfiler.DatadogTracing.UnitTest/MetricTagAllocationTest.cs
@@ -1,0 +1,73 @@
+using ClrProfiler.DatadogTracing;
+using ClrProfiler.Statistics;
+using Microsoft.Extensions.Logging;
+
+namespace CleProfiler.DatadogTracing.UnitTest;
+
+public class MetricTagAllocationTest
+{
+    private const int Iterations = 10_000;
+    private static readonly ILogger DisabledLogger = new DisabledLoggerImplementation();
+    private static readonly GCStartEndStatistics Statistics = new(1, 0, 2, 1, 1.5, 100, 200);
+
+    [Test]
+    public async Task LoggerGcEventStartEnd_ReusesPrecomputedTags()
+    {
+        for (var i = 0; i < 1_000; i++)
+        {
+            LoggerTracing.GcEventStartEnd(Statistics, DisabledLogger);
+        }
+
+        var before = GC.GetAllocatedBytesForCurrentThread();
+        for (var i = 0; i < Iterations; i++)
+        {
+            LoggerTracing.GcEventStartEnd(Statistics, DisabledLogger);
+        }
+        var allocatedBytes = GC.GetAllocatedBytesForCurrentThread() - before;
+
+        Console.WriteLine($"Allocated bytes: {allocatedBytes}; bytes/call: {(double)allocatedBytes / Iterations:N2}");
+        await Assert.That(allocatedBytes).IsLessThanOrEqualTo(480L * Iterations);
+    }
+
+    [Test]
+    public async Task MetricTagLookup_DoesNotAllocateAfterInitialization()
+    {
+        UseAllTagKinds();
+
+        var before = GC.GetAllocatedBytesForCurrentThread();
+        for (var i = 0; i < Iterations; i++)
+        {
+            UseAllTagKinds();
+        }
+        var allocatedBytes = GC.GetAllocatedBytesForCurrentThread() - before;
+
+        await Assert.That(allocatedBytes).IsEqualTo(0);
+    }
+
+    private static void UseAllTagKinds()
+    {
+        ref readonly var contention = ref MetricTags.GetContention(1);
+        ref readonly var gc = ref MetricTags.GetGcStartEnd(2, 1, 10);
+        ref readonly var suspend = ref MetricTags.GetGcSuspend(6);
+        ref readonly var thread = ref MetricTags.GetThreadAdjustment(8);
+        ref readonly var gcInfo = ref MetricTags.GetGcInfo(
+            GCMode.Server,
+            System.Runtime.GCLatencyMode.SustainedLowLatency,
+            System.Runtime.GCLargeObjectHeapCompactionMode.CompactOnce);
+
+        GC.KeepAlive(contention.Text);
+        GC.KeepAlive(gc.Text);
+        GC.KeepAlive(suspend.Text);
+        GC.KeepAlive(thread.Text);
+        GC.KeepAlive(gcInfo.Loh.Text);
+    }
+
+    private sealed class DisabledLoggerImplementation : ILogger
+    {
+        public IDisposable? BeginScope<TState>(TState state) where TState : notnull => null;
+        public bool IsEnabled(LogLevel logLevel) => false;
+        public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception, Func<TState, Exception?, string> formatter)
+        {
+        }
+    }
+}

--- a/tests/CleProfiler.DatadogTracing.UnitTest/MetricTagProjectionTest.cs
+++ b/tests/CleProfiler.DatadogTracing.UnitTest/MetricTagProjectionTest.cs
@@ -16,6 +16,7 @@ public class MetricTagProjectionTest
 
         LoggerTracing.ContentionEventStartEnd(new ContentionEventStatistics(1, flag, 2.5), logger);
 
+        await Assert.That(logger.Messages).Count().IsEqualTo(2);
         foreach (var message in logger.Messages)
         {
             await Assert.That(message).Contains($"tags: contention_type:{flag}");
@@ -40,6 +41,7 @@ public class MetricTagProjectionTest
 
         LoggerTracing.GcEventStartEnd(new GCStartEndStatistics(1, 1, 2, reason, 1.5, 100, 200), logger);
 
+        await Assert.That(logger.Messages).Count().IsEqualTo(2);
         foreach (var message in logger.Messages)
         {
             await Assert.That(message).Contains($"tags: gc_gen:2,gc_type:1,gc_reason:{reasonText}");
@@ -60,6 +62,7 @@ public class MetricTagProjectionTest
 
         LoggerTracing.GcEventSuspend(new GCSuspendStatistics(1.5, reason, 3), logger);
 
+        await Assert.That(logger.Messages).Count().IsEqualTo(2);
         foreach (var message in logger.Messages)
         {
             await Assert.That(message).Contains($"tags: gc_suspend_reason:{reasonText}");
@@ -82,9 +85,81 @@ public class MetricTagProjectionTest
 
         LoggerTracing.ThreadPoolEventAdjustment(new ThreadPoolAdjustmentStatistics(1, 2.5, 3, reason), logger);
 
+        await Assert.That(logger.Messages).Count().IsEqualTo(2);
         foreach (var message in logger.Messages)
         {
             await Assert.That(message).Contains($"tags: thread_adjust_reason:{reasonText}");
+        }
+    }
+
+    [Test]
+    public async Task UnknownRuntimeValues_UseBoundedUnknownTags()
+    {
+        var logger = new CapturingLogger();
+
+        LoggerTracing.ContentionEventStartEnd(new ContentionEventStatistics(1, byte.MaxValue, 2.5), logger);
+        LoggerTracing.GcEventStartEnd(new GCStartEndStatistics(1, uint.MaxValue, uint.MaxValue, uint.MaxValue, 1.5, 100, 200), logger);
+        LoggerTracing.GcEventSuspend(new GCSuspendStatistics(1.5, uint.MaxValue, 3), logger);
+        LoggerTracing.ThreadPoolEventAdjustment(new ThreadPoolAdjustmentStatistics(1, 2.5, 3, uint.MaxValue), logger);
+        LoggerTracing.GcInfoTimerGauge(new GCInfoStatistics(
+            DateTime.UnixEpoch,
+            (GCMode)int.MaxValue,
+            (GCLargeObjectHeapCompactionMode)int.MaxValue,
+            (GCLatencyMode)int.MaxValue,
+            1,
+            2,
+            3,
+            4,
+            5,
+            6,
+            7,
+            8,
+            9,
+            10), logger);
+
+        await Assert.That(logger.Messages).Contains(message => message.Contains("tags: contention_type:unknown"));
+        await Assert.That(logger.Messages).Contains(message => message.Contains("tags: gc_gen:unknown,gc_type:unknown,gc_reason:unknown"));
+        await Assert.That(logger.Messages).Contains(message => message.Contains("tags: gc_suspend_reason:unknown"));
+        await Assert.That(logger.Messages).Contains(message => message.Contains("tags: thread_adjust_reason:unknown"));
+        await Assert.That(logger.Messages).Contains(message => message.Contains("tags: gc_mode:unknown,latency_mode:unknown,compaction_mode:unknown"));
+    }
+
+    [Test]
+    public async Task PrecomputedGcTags_ReuseSharedComponentStrings()
+    {
+        ref readonly var first = ref MetricTags.GetGcStartEnd(2, 0, 1);
+        ref readonly var second = ref MetricTags.GetGcStartEnd(2, 1, 1);
+        var firstGeneration = first.Values[0];
+        var secondGeneration = second.Values[0];
+        var firstReason = first.Values[2];
+        var secondReason = second.Values[2];
+
+        await Assert.That(ReferenceEquals(firstGeneration, secondGeneration)).IsTrue();
+        await Assert.That(ReferenceEquals(firstReason, secondReason)).IsTrue();
+    }
+
+    [Test]
+    public async Task PrecomputedReasonTags_StayAlignedWithStatisticsMappings()
+    {
+        for (uint reason = 0; reason <= 10; reason++)
+        {
+            var statistics = new GCStartEndStatistics(0, 0, 0, reason, 0, 0, 0);
+            var tags = MetricTags.GetGcStartEnd(0, 0, reason);
+            await Assert.That(tags.Values[2]).IsEqualTo($"gc_reason:{statistics.GetReasonString()}");
+        }
+
+        for (uint reason = 0; reason <= 6; reason++)
+        {
+            var statistics = new GCSuspendStatistics(0, reason, 0);
+            var tags = MetricTags.GetGcSuspend(reason);
+            await Assert.That(tags.Values[0]).IsEqualTo($"gc_suspend_reason:{statistics.GetReasonString()}");
+        }
+
+        for (uint reason = 0; reason <= 8; reason++)
+        {
+            var statistics = new ThreadPoolAdjustmentStatistics(0, 0, 0, reason);
+            var tags = MetricTags.GetThreadAdjustment(reason);
+            await Assert.That(tags.Values[0]).IsEqualTo($"thread_adjust_reason:{statistics.GetReasonString()}");
         }
     }
 

--- a/tests/CleProfiler.DatadogTracing.UnitTest/MetricTagProjectionTest.cs
+++ b/tests/CleProfiler.DatadogTracing.UnitTest/MetricTagProjectionTest.cs
@@ -1,0 +1,130 @@
+using ClrProfiler.DatadogTracing;
+using ClrProfiler.Statistics;
+using Microsoft.Extensions.Logging;
+using System.Runtime;
+
+namespace CleProfiler.DatadogTracing.UnitTest;
+
+public class MetricTagProjectionTest
+{
+    [Test]
+    [Arguments((byte)0)]
+    [Arguments((byte)1)]
+    public async Task ContentionEventStartEnd_PreservesTags(byte flag)
+    {
+        var logger = new CapturingLogger();
+
+        LoggerTracing.ContentionEventStartEnd(new ContentionEventStatistics(1, flag, 2.5), logger);
+
+        foreach (var message in logger.Messages)
+        {
+            await Assert.That(message).Contains($"tags: contention_type:{flag}");
+        }
+    }
+
+    [Test]
+    [Arguments(0u, "soh")]
+    [Arguments(1u, "induced")]
+    [Arguments(2u, "low_memory")]
+    [Arguments(3u, "empty")]
+    [Arguments(4u, "loh")]
+    [Arguments(5u, "oos_soh")]
+    [Arguments(6u, "oos_loh")]
+    [Arguments(7u, "incuded_non_forceblock")]
+    [Arguments(8u, "stress_testing")]
+    [Arguments(9u, "finalizer_low_memory_induced")]
+    [Arguments(10u, "user_gc_request")]
+    public async Task GcEventStartEnd_PreservesTags(uint reason, string reasonText)
+    {
+        var logger = new CapturingLogger();
+
+        LoggerTracing.GcEventStartEnd(new GCStartEndStatistics(1, 1, 2, reason, 1.5, 100, 200), logger);
+
+        foreach (var message in logger.Messages)
+        {
+            await Assert.That(message).Contains($"tags: gc_gen:2,gc_type:1,gc_reason:{reasonText}");
+        }
+    }
+
+    [Test]
+    [Arguments(0u, "other")]
+    [Arguments(1u, "gc")]
+    [Arguments(2u, "appdomain_shudown")]
+    [Arguments(3u, "code_pitch")]
+    [Arguments(4u, "shutdown")]
+    [Arguments(5u, "debugger")]
+    [Arguments(6u, "prep_gc")]
+    public async Task GcEventSuspend_PreservesTags(uint reason, string reasonText)
+    {
+        var logger = new CapturingLogger();
+
+        LoggerTracing.GcEventSuspend(new GCSuspendStatistics(1.5, reason, 3), logger);
+
+        foreach (var message in logger.Messages)
+        {
+            await Assert.That(message).Contains($"tags: gc_suspend_reason:{reasonText}");
+        }
+    }
+
+    [Test]
+    [Arguments(0u, "warmup")]
+    [Arguments(1u, "initializing")]
+    [Arguments(2u, "random_move")]
+    [Arguments(3u, "climbing_move")]
+    [Arguments(4u, "change_point")]
+    [Arguments(5u, "stabilizing")]
+    [Arguments(6u, "starvation")]
+    [Arguments(7u, "timedout")]
+    [Arguments(8u, "cooperative_blocking")]
+    public async Task ThreadPoolEventAdjustment_PreservesTags(uint reason, string reasonText)
+    {
+        var logger = new CapturingLogger();
+
+        LoggerTracing.ThreadPoolEventAdjustment(new ThreadPoolAdjustmentStatistics(1, 2.5, 3, reason), logger);
+
+        foreach (var message in logger.Messages)
+        {
+            await Assert.That(message).Contains($"tags: thread_adjust_reason:{reasonText}");
+        }
+    }
+
+    [Test]
+    public async Task GcInfoTimerGauge_PreservesBaseAndGenerationTagOrder()
+    {
+        var logger = new CapturingLogger();
+        var statistics = new GCInfoStatistics(
+            DateTime.UnixEpoch,
+            GCMode.Server,
+            GCLargeObjectHeapCompactionMode.CompactOnce,
+            GCLatencyMode.SustainedLowLatency,
+            1,
+            2,
+            3,
+            4,
+            5,
+            6,
+            7,
+            8,
+            9,
+            10);
+
+        LoggerTracing.GcInfoTimerGauge(statistics, logger);
+
+        await Assert.That(logger.Messages[0]).Contains("tags: gc_mode:Server,latency_mode:SustainedLowLatency,compaction_mode:CompactOnce");
+        await Assert.That(logger.Messages[2]).Contains("tags: gc_gen:0,gc_mode:Server,latency_mode:SustainedLowLatency,compaction_mode:CompactOnce");
+        await Assert.That(logger.Messages[8]).Contains("tags: gc_gen:loh,gc_mode:Server,latency_mode:SustainedLowLatency,compaction_mode:CompactOnce");
+    }
+
+    private sealed class CapturingLogger : ILogger
+    {
+        public List<string> Messages { get; } = [];
+
+        public IDisposable? BeginScope<TState>(TState state) where TState : notnull => null;
+        public bool IsEnabled(LogLevel logLevel) => true;
+
+        public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception, Func<TState, Exception?, string> formatter)
+        {
+            Messages.Add(formatter(state, exception));
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Precompute all metric tags during tracker initialization.
- Remove dictionaries and ZString formatting from metric hot paths.
- Use source-generated logging to avoid disabled-log allocations.
- Centralize metric names and tag contracts in `MetricNames`.
- Add bounded `unknown` tags for unexpected runtime values.

## Intent

Reduce profiling overhead and keep steady-state metric projection allocation-free while preserving metric compatibility and making the emitted metrics easier to audit.

## Benchmark

- Hot-path tag lookup: **0 B allocated**
- Disabled logger metric projection: **0 B allocated**
- Release build: **0 warnings / 0 errors**
- Tests: **69 passed**
- No standalone throughput benchmark was performed.