### PR TITLE
feat: atomic contention handling

### DIFF
--- a/.claude/skills/performance-requirements/SKILL.md
+++ b/.claude/skills/performance-requirements/SKILL.md
@@ -40,15 +40,30 @@ Treat overhead added to the profiled process as part of ClrProfiler's correctnes
 
 ## Verify performance changes
 
-The repository currently has no committed benchmark project, so do not claim a numeric performance improvement from stopwatch timing or from the functional test suite.
+Do not claim a numeric performance improvement from stopwatch timing or from the functional test suite. Use the committed benchmark project at `src/ClrProfiler.Benchmarks`.
+
+`E2EBenchmarks` measures representative workloads with every listener disabled and enabled, driven by a `TrackingEnabled` parameter, so each benchmark reports the overhead the profiler adds:
+
+- `AllocationAndGc` — allocate 1 MiB and force a Gen0 collection
+- `Contention` — contended monitor across parallel operations
+- `ThreadPoolDispatch` — parallel ThreadPool dispatch
+
+It is configured with `MemoryDiagnoser` and `Job.ShortRun`, and uses `BenchmarkSwitcher`, so BenchmarkDotNet's own `--filter` argument selects benchmarks. The project multi-targets `net8.0`, `net9.0`, and `net10.0`, so a target framework must be given explicitly:
+
+```powershell
+dotnet run -c Release --project src/ClrProfiler.Benchmarks -f net9.0 -- --list flat
+dotnet run -c Release --project src/ClrProfiler.Benchmarks -f net9.0 -- --filter "*Contention*"
+```
 
 For a meaningful hot-path change:
 
 1. Run the relevant correctness and data-integrity tests first.
 2. Measure the old and new implementations with the same Release build, runtime, event payload, event count, warmup, and invocation method.
 3. Record throughput and allocated bytes. Also inspect Gen0 collections when allocation behavior changes.
-4. Add a focused BenchmarkDotNet project or benchmark only when repeatable performance gating is part of the task; keep it separate from the sample applications.
+4. Extend `src/ClrProfiler.Benchmarks` when an existing benchmark does not cover the changed path. Add a separate BenchmarkDotNet project only when a task needs isolated performance gating, and keep benchmarks out of the sample applications.
 5. Reject unexplained event loss, ordering changes, unbounded state, or allocation regressions even when mean time improves.
+
+An allocation assertion in the test suite is a complement to benchmarking, not a substitute, and it has its own trap: a measured loop left in tier-0 code is replaced mid-flight by an on-stack replacement transition that itself allocates on the executing thread. Put the measured loop in its own method marked `[MethodImpl(MethodImplOptions.NoInlining | MethodImplOptions.AggressiveOptimization)]` and run the same method for warmup, as `tests/CleProfiler.DatadogTracing.UnitTest/MetricTagAllocationTest.cs` does. Otherwise the result depends on test execution order.
 
 Always run the repository's Release build and tests after a performance-sensitive change:
 

--- a/.claude/skills/sandbox-code-guidelines/SKILL.md
+++ b/.claude/skills/sandbox-code-guidelines/SKILL.md
@@ -1,16 +1,16 @@
 ---
 name: sandbox-code-guidelines
-description: Guidelines for ClrProfiler experiments and manual demonstrations using `src/ConsoleApp` and `src/CustomConsoleApp`. Use for exploratory CLR event generation, timer sampling, lifecycle checks, custom callback handlers, console or Datadog metric inspection, and small performance probes that are not yet production tests.
+description: Guidelines for ClrProfiler experiments and manual demonstrations using `sandbox/ConsoleApp` and `sandbox/CustomConsoleApp`. Use for exploratory CLR event generation, timer sampling, lifecycle checks, custom callback handlers, console or Datadog metric inspection, and small performance probes that are not yet production tests.
 ---
 
 # Sandbox Code Guidelines
 
 Use the existing sample applications for manual or exploratory work:
 
-- `src/ConsoleApp`: exercise the packaged Datadog adapter and local DogStatsD-style flow.
-- `src/CustomConsoleApp`: exercise `IClrTrackerCallbackHandler` and custom metric handling.
+- `sandbox/ConsoleApp`: exercise the packaged Datadog adapter and local DogStatsD-style flow.
+- `sandbox/CustomConsoleApp`: exercise `IClrTrackerCallbackHandler` and custom metric handling.
 
-Do not use `dotnet-script` or assume that `sandbox/DotnetFiles` exists. Prefer a focused xUnit test when the behavior can be verified deterministically.
+Do not use `dotnet-script`. Prefer a focused TUnit test when the behavior can be verified deterministically; see `test-first-development` for the conventions.
 
 ## Workflow
 
@@ -19,11 +19,11 @@ Do not use `dotnet-script` or assume that `sandbox/DotnetFiles` exists. Prefer a
 3. Run the sample in Release mode from the repository root:
 
 ```powershell
-dotnet run -c Release --project src/ConsoleApp/ConsoleApp.csproj
-dotnet run -c Release --project src/CustomConsoleApp/CustomConsoleApp.csproj
+dotnet run -c Release --project sandbox/ConsoleApp/ConsoleApp.csproj
+dotnet run -c Release --project sandbox/CustomConsoleApp/CustomConsoleApp.csproj
 ```
 
-4. Convert confirmed behavior into the appropriate xUnit project before changing production code.
+4. Convert confirmed behavior into the appropriate test project before changing production code.
 5. Remove task-specific probes, delays, and forced allocations unless they improve the maintained sample itself.
 
 ## Guardrails

--- a/.claude/skills/test-first-development/SKILL.md
+++ b/.claude/skills/test-first-development/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: test-first-development
-description: Mandatory test-first workflow for changes under `src/` in ClrProfiler. Covers CLR EventListener parsing and correlation, bounded-channel delivery, timer sampling, profiler and tracker lifecycle, callback error handling, statistics values, Datadog or logger metric projection, multi-target builds, and regression verification with xUnit v3.
+description: Mandatory test-first workflow for changes under `src/` in ClrProfiler. Covers CLR EventListener parsing and correlation, bounded-channel delivery, timer sampling, profiler and tracker lifecycle, callback error handling, statistics values, Datadog or logger metric projection, multi-target builds, and regression verification with TUnit.
 ---
 
 # Test-First Development
@@ -27,20 +27,53 @@ For a behavior-preserving performance refactor, first prove the relevant tests p
 
 The `CleProfiler.DatadogTracing.UnitTest` directory contains an existing `CleProfiler` spelling. Use the path as it exists; do not rename it as an incidental cleanup.
 
-This repository uses xUnit v3. Use `[Fact]` and `[Theory]`, synchronous `Assert` APIs, and `dotnet test` filtering when a targeted run is useful:
+## Write TUnit tests
+
+This repository uses TUnit on Microsoft Testing Platform. It is not xUnit or NUnit, and VSTest options do not apply.
+
+- Mark tests with `[Test]`, not `[Fact]`.
+- Supply cases with `[Arguments(...)]`, not `[Theory]`/`[InlineData]`.
+- Assertions are fluent and must be awaited: `await Assert.That(actual).IsEqualTo(expected)`. Common forms include `.IsTrue()`, `.Contains(...)`, `.DoesNotContain(...)`, `.HasSingleItem()`, and `.Count().IsEqualTo(n)`. `HasSingleItem()` returns the item, so `var result = await Assert.That(list).HasSingleItem();` is the idiomatic single-result assertion.
+- Serialize tests that touch process-wide state with `[NotInParallel]` on the class.
+- Inside a test, `TestContext.Current!.Execution.CancellationToken` is the ambient token for `WaitAsync` and similar bounded waits.
+
+See `tests/ClrProfiler.UnitTest/EventListenerDataIntegrityTest.cs` and `tests/CleProfiler.DatadogTracing.UnitTest/MetricTagProjectionTest.cs` for the established style.
+
+## Run tests
+
+Filter with `--treenode-filter` using a `/assembly/namespace/class/method` path. VSTest's `--filter` is rejected outright by the test executable (`Unknown option '--filter'`), and passing it through `dotnet test` silently selects zero tests and still exits non-zero, which reads like a pass if the summary is not checked. `--logger "console;verbosity=normal"` fails the same way.
 
 ```powershell
-dotnet test tests/ClrProfiler.UnitTest/ClrProfiler.UnitTest.csproj -c Release --filter "FullyQualifiedName~ProfilerLifecycleTest"
-dotnet test tests/CleProfiler.DatadogTracing.UnitTest/CleProfiler.DatadogTracing.UnitTest.csproj -c Release --filter "FullyQualifiedName~DatadogTracingUnitTest"
+dotnet test tests/ClrProfiler.UnitTest/ClrProfiler.UnitTest.csproj -c Release --treenode-filter "/*/*/ProfilerLifecycleTest/*"
+dotnet test tests/CleProfiler.DatadogTracing.UnitTest/CleProfiler.DatadogTracing.UnitTest.csproj -c Release --treenode-filter "/*/*/DatadogTracingUnitTest/*"
 ```
 
-Finish with the CI-equivalent sequence:
+Wildcards apply per path segment, so `/*/*/*AllocationTest/*` selects every matching class. A comma-separated list and `(A|B)` alternation are not supported; use a wildcard that covers both classes, or run them separately.
+
+Always read the summary counts, not just the exit code. A filter that matches nothing reports `total: 0`.
+
+Finish with the sequence `.github/workflows/build.yaml` runs:
 
 ```powershell
 dotnet build -c Release
-dotnet test -c Release --no-build --logger "console;verbosity=normal"
-dotnet pack -c Release --no-build
+dotnet test -c Release --no-build
+dotnet pack -c Release
 ```
+
+### When the net9.0 runtime is missing locally
+
+The test projects target `net9.0` only. `dotnet test` then fails to launch with `Framework 'Microsoft.NETCore.App', version '9.0.0' not found` and reports `Zero tests ran`, and `DOTNET_ROLL_FORWARD` does not help through the `dotnet test` driver. Run the built test executable directly instead:
+
+```powershell
+dotnet build -c Release
+$env:DOTNET_ROLL_FORWARD = "LatestMajor"
+tests/ClrProfiler.UnitTest/bin/Release/net9.0/ClrProfiler.UnitTest.exe --treenode-filter "/*/*/ProfilerLifecycleTest/*"
+tests/CleProfiler.DatadogTracing.UnitTest/bin/Release/net9.0/CleProfiler.DatadogTracing.UnitTest.exe
+```
+
+Add `--output Detailed` to see per-test results and any `Console.WriteLine` diagnostics; the default output shows only the summary.
+
+Do not work around this by adding target frameworks to the test projects. CI provisions the runtime and runs `dotnet test` normally.
 
 ## Test the right boundary
 
@@ -90,5 +123,7 @@ Choose the applicable cases; do not add unrelated tests.
 ## Multi-target and compatibility checks
 
 The core library targets `net8.0`, `net9.0`, and `net10.0`; the Datadog adapter targets `net8.0` and `net9.0`; tests currently run on `net9.0`. A passing test target does not prove all library targets compile, so always run the solution build after changing production code.
+
+Because the test projects declare a single target framework, `dotnet test -f net8.0` fails with `NETSDK1005` rather than running anything. Verify other targets with `dotnet build -c Release` over the solution.
 
 Keep `ClrProfiler` zero-dependency. Do not move adapter packages into the core project to simplify a test.

--- a/README.md
+++ b/README.md
@@ -152,6 +152,8 @@ Every event contributes to `Count` and `DurationNsSum`, so no duration is discar
 
 Aggregates are reset per dispatch. A single event's duration may be attributed to the dispatch immediately before the one carrying its count, so an individual value can be skewed by one event under concurrency. Totals across dispatches are exact.
 
+Stopping the profiler seals whatever is still aggregated and dispatches it as its own value, keeping the timestamp of the events it represents. Nothing observed before a stop is discarded, and nothing carries over into the events that arrive after a restart.
+
 A dispatch happens every time the reader drains, which is far more often than a metrics backend flushes. Contention metrics therefore only use statsd types that aggregate correctly over many submissions within one flush interval:
 
 | Metric | statsd type | Value | Why the type |

--- a/README.md
+++ b/README.md
@@ -138,7 +138,21 @@ tracker.StartTracker();
 
 This approach allows you to integrate ClrProfiler with any metrics backend or implement custom logic for processing CLR events.
 
-Contention callbacks atomically aggregate event counts by contention flag before dispatch. `ContentionEventStatistics.Count` is the represented event count and `DurationNs` is the latest observed duration for that flag. This prevents contention bursts from losing counts when callback delivery is slower than event ingestion, without blocking or spinning in the event producer or reader paths.
+Contention callbacks aggregate events by contention flag before dispatch, so one `ContentionEventStatistics` can represent many events. This keeps contention bursts intact when callback delivery is slower than event ingestion, without blocking the event producer.
+
+| Member | Meaning |
+| --- | --- |
+| `Count` | Number of contention events represented by this value. |
+| `DurationNsSum` | Total contention duration in nanoseconds across those events. |
+| `DurationNsMax` | Longest single contention duration in nanoseconds among those events. |
+| `DurationNsMean` | `DurationNsSum / Count`, or 0 when nothing was aggregated. |
+| `Time` | Timestamp of the newest event observed for the flag. The duration fields summarize the whole window, so they are not tied to this timestamp. |
+
+Every event contributes to `Count` and `DurationNsSum`, so no duration is discarded no matter how large the burst. Durations accumulate as whole picoseconds internally, which keeps the per-event fold to a single lock-free add; non-finite or negative payload durations contribute 0 while still being counted.
+
+Aggregates are reset per dispatch. A single event's duration may be attributed to the dispatch immediately before the one carrying its count, so an individual value can be skewed by one event under concurrency. Totals across dispatches are exact.
+
+The Datadog and logger adapters project this as `startend_count` (counter, `Count`), `startend_duration_ns` (gauge, `DurationNsMax`), and `startend_duration_ns_sum` (counter, `DurationNsSum`). Divide the last by the first for the mean.
 
 ## Sandbox
 

--- a/README.md
+++ b/README.md
@@ -152,7 +152,17 @@ Every event contributes to `Count` and `DurationNsSum`, so no duration is discar
 
 Aggregates are reset per dispatch. A single event's duration may be attributed to the dispatch immediately before the one carrying its count, so an individual value can be skewed by one event under concurrency. Totals across dispatches are exact.
 
-The Datadog and logger adapters project this as `startend_count` (counter, `Count`), `startend_duration_ns` (gauge, `DurationNsMax`), and `startend_duration_ns_sum` (counter, `DurationNsSum`). Divide the last by the first for the mean.
+A dispatch happens every time the reader drains, which is far more often than a metrics backend flushes. Contention metrics therefore only use statsd types that aggregate correctly over many submissions within one flush interval:
+
+| Metric | statsd type | Value | Why the type |
+| --- | --- | --- | --- |
+| `clr_diagnostics_event.contention.startend_count` | counter | `Count` | Counts add, so every dispatch is kept. |
+| `clr_diagnostics_event.contention.startend_duration_ns_sum` | counter | `DurationNsSum` | Sums add, so no duration is discarded. |
+| `clr_diagnostics_event.contention.startend_duration_ns_max` | histogram | `DurationNsMax` | The maximum of the submitted window maxima is the true maximum for the interval. |
+
+Read `startend_duration_ns_max.max` for the worst contention in an interval, and `startend_duration_ns_sum / startend_count` for the exact mean duration. The `.avg`, `.count`, and percentile series derived from the histogram describe window maxima rather than individual contentions, so do not read them as durations.
+
+A gauge is deliberately not used for any of these. A gauge keeps only the last value submitted within a flush interval, which would discard every aggregation window but one.
 
 ## Sandbox
 

--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ tracker.StartTracker();
 
 This approach allows you to integrate ClrProfiler with any metrics backend or implement custom logic for processing CLR events.
 
-Contention callbacks are atomically aggregated by contention flag before dispatch. `ContentionEventStatistics.Count` is the represented event count, `DurationNs` is their total duration, and `AverageDurationNs` is the per-event average. This prevents contention bursts from losing counts when callback delivery is slower than event ingestion.
+Contention callbacks atomically aggregate event counts by contention flag before dispatch. `ContentionEventStatistics.Count` is the represented event count and `DurationNs` is the latest observed duration for that flag. This prevents contention bursts from losing counts when callback delivery is slower than event ingestion, without blocking or spinning in the event producer or reader paths.
 
 ## Sandbox
 

--- a/README.md
+++ b/README.md
@@ -138,6 +138,8 @@ tracker.StartTracker();
 
 This approach allows you to integrate ClrProfiler with any metrics backend or implement custom logic for processing CLR events.
 
+Contention callbacks are atomically aggregated by contention flag before dispatch. `ContentionEventStatistics.Count` is the represented event count, `DurationNs` is their total duration, and `AverageDurationNs` is the per-event average. This prevents contention bursts from losing counts when callback delivery is slower than event ingestion.
+
 ## Sandbox
 
 Run ConsoleApp, then metrics ingested will shown on Console. Sandbox runs both Server and Client. Server is listen UDP Server on `127.0.0.1:8125` and accept request from local datadog agent.

--- a/src/ClrProfiler.DatadogTracing/DatadogTracing.cs
+++ b/src/ClrProfiler.DatadogTracing/DatadogTracing.cs
@@ -10,7 +10,8 @@ public static class DatadogTracing
     {
         ref readonly var tags = ref MetricTags.GetContention(statistics.Flag);
         DogStatsd.Counter(MetricNames.Event.ContentionStartEndCount, statistics.Count, tags: tags.Values);
-        DogStatsd.Gauge(MetricNames.Event.ContentionStartEndDurationNs, statistics.DurationNs, tags: tags.Values);
+        DogStatsd.Gauge(MetricNames.Event.ContentionStartEndDurationNs, statistics.DurationNsMax, tags: tags.Values);
+        DogStatsd.Counter(MetricNames.Event.ContentionStartEndDurationNsSum, statistics.DurationNsSum, tags: tags.Values);
     }
 
     // GCEvent

--- a/src/ClrProfiler.DatadogTracing/DatadogTracing.cs
+++ b/src/ClrProfiler.DatadogTracing/DatadogTracing.cs
@@ -9,8 +9,8 @@ public static class DatadogTracing
     public static void ContentionEventStartEnd(in ContentionEventStatistics statistics)
     {
         ref readonly var tags = ref MetricTags.GetContention(statistics.Flag);
-        DogStatsd.Increment(MetricNames.Event.ContentionStartEndCount, tags: tags.Values);
-        DogStatsd.Gauge(MetricNames.Event.ContentionStartEndDurationNs, statistics.DurationNs, tags: tags.Values);
+        DogStatsd.Counter(MetricNames.Event.ContentionStartEndCount, statistics.Count, tags: tags.Values);
+        DogStatsd.Gauge(MetricNames.Event.ContentionStartEndDurationNs, statistics.AverageDurationNs, tags: tags.Values);
     }
 
     // GCEvent

--- a/src/ClrProfiler.DatadogTracing/DatadogTracing.cs
+++ b/src/ClrProfiler.DatadogTracing/DatadogTracing.cs
@@ -9,9 +9,12 @@ public static class DatadogTracing
     public static void ContentionEventStartEnd(in ContentionEventStatistics statistics)
     {
         ref readonly var tags = ref MetricTags.GetContention(statistics.Flag);
+        // Counters and histograms are the only types that survive interval aggregation here: the
+        // listener emits an aggregation window whenever the reader drains, which is far more often
+        // than statsd flushes. A gauge would keep the last window and discard every other one.
         DogStatsd.Counter(MetricNames.Event.ContentionStartEndCount, statistics.Count, tags: tags.Values);
-        DogStatsd.Gauge(MetricNames.Event.ContentionStartEndDurationNs, statistics.DurationNsMax, tags: tags.Values);
         DogStatsd.Counter(MetricNames.Event.ContentionStartEndDurationNsSum, statistics.DurationNsSum, tags: tags.Values);
+        DogStatsd.Histogram(MetricNames.Event.ContentionStartEndDurationNsMax, statistics.DurationNsMax, tags: tags.Values);
     }
 
     // GCEvent

--- a/src/ClrProfiler.DatadogTracing/DatadogTracing.cs
+++ b/src/ClrProfiler.DatadogTracing/DatadogTracing.cs
@@ -10,7 +10,7 @@ public static class DatadogTracing
     {
         ref readonly var tags = ref MetricTags.GetContention(statistics.Flag);
         DogStatsd.Counter(MetricNames.Event.ContentionStartEndCount, statistics.Count, tags: tags.Values);
-        DogStatsd.Gauge(MetricNames.Event.ContentionStartEndDurationNs, statistics.AverageDurationNs, tags: tags.Values);
+        DogStatsd.Gauge(MetricNames.Event.ContentionStartEndDurationNs, statistics.DurationNs, tags: tags.Values);
     }
 
     // GCEvent

--- a/src/ClrProfiler.DatadogTracing/LoggerTracing.cs
+++ b/src/ClrProfiler.DatadogTracing/LoggerTracing.cs
@@ -9,8 +9,8 @@ public static partial class LoggerTracing
     {
         ref readonly var tags = ref MetricTags.GetContention(statistics.Flag);
         LogLongMetric(logger, MetricNames.Event.ContentionStartEndCount, statistics.Count, tags.Text);
-        LogDoubleMetric(logger, MetricNames.Event.ContentionStartEndDurationNs, statistics.DurationNsMax, tags.Text);
         LogDoubleMetric(logger, MetricNames.Event.ContentionStartEndDurationNsSum, statistics.DurationNsSum, tags.Text);
+        LogDoubleMetric(logger, MetricNames.Event.ContentionStartEndDurationNsMax, statistics.DurationNsMax, tags.Text);
     }
 
     public static void GcEventStartEnd(in GCStartEndStatistics statistics, ILogger logger)

--- a/src/ClrProfiler.DatadogTracing/LoggerTracing.cs
+++ b/src/ClrProfiler.DatadogTracing/LoggerTracing.cs
@@ -9,7 +9,8 @@ public static partial class LoggerTracing
     {
         ref readonly var tags = ref MetricTags.GetContention(statistics.Flag);
         LogLongMetric(logger, MetricNames.Event.ContentionStartEndCount, statistics.Count, tags.Text);
-        LogDoubleMetric(logger, MetricNames.Event.ContentionStartEndDurationNs, statistics.DurationNs, tags.Text);
+        LogDoubleMetric(logger, MetricNames.Event.ContentionStartEndDurationNs, statistics.DurationNsMax, tags.Text);
+        LogDoubleMetric(logger, MetricNames.Event.ContentionStartEndDurationNsSum, statistics.DurationNsSum, tags.Text);
     }
 
     public static void GcEventStartEnd(in GCStartEndStatistics statistics, ILogger logger)

--- a/src/ClrProfiler.DatadogTracing/LoggerTracing.cs
+++ b/src/ClrProfiler.DatadogTracing/LoggerTracing.cs
@@ -9,7 +9,7 @@ public static partial class LoggerTracing
     {
         ref readonly var tags = ref MetricTags.GetContention(statistics.Flag);
         LogLongMetric(logger, MetricNames.Event.ContentionStartEndCount, statistics.Count, tags.Text);
-        LogDoubleMetric(logger, MetricNames.Event.ContentionStartEndDurationNs, statistics.AverageDurationNs, tags.Text);
+        LogDoubleMetric(logger, MetricNames.Event.ContentionStartEndDurationNs, statistics.DurationNs, tags.Text);
     }
 
     public static void GcEventStartEnd(in GCStartEndStatistics statistics, ILogger logger)

--- a/src/ClrProfiler.DatadogTracing/LoggerTracing.cs
+++ b/src/ClrProfiler.DatadogTracing/LoggerTracing.cs
@@ -8,8 +8,8 @@ public static partial class LoggerTracing
     public static void ContentionEventStartEnd(in ContentionEventStatistics statistics, ILogger logger)
     {
         ref readonly var tags = ref MetricTags.GetContention(statistics.Flag);
-        LogIntMetric(logger, MetricNames.Event.ContentionStartEndCount, 1, tags.Text);
-        LogDoubleMetric(logger, MetricNames.Event.ContentionStartEndDurationNs, statistics.DurationNs, tags.Text);
+        LogLongMetric(logger, MetricNames.Event.ContentionStartEndCount, statistics.Count, tags.Text);
+        LogDoubleMetric(logger, MetricNames.Event.ContentionStartEndDurationNs, statistics.AverageDurationNs, tags.Text);
     }
 
     public static void GcEventStartEnd(in GCStartEndStatistics statistics, ILogger logger)

--- a/src/ClrProfiler.DatadogTracing/MetricNames.cs
+++ b/src/ClrProfiler.DatadogTracing/MetricNames.cs
@@ -23,10 +23,10 @@ internal static class MetricNames
     /// </remarks>
     internal static class Event
     {
-        /// <summary>Counter. Tags: <c>contention_type:0|1|unknown</c>.</summary>
+        /// <summary>Counter incremented by the aggregated contention count. Tags: <c>contention_type:0|1|unknown</c>.</summary>
         internal const string ContentionStartEndCount = "clr_diagnostics_event.contention.startend_count";
 
-        /// <summary>Gauge in nanoseconds. Tags: <c>contention_type:0|1|unknown</c>.</summary>
+        /// <summary>Gauge of average contention duration in nanoseconds. Tags: <c>contention_type:0|1|unknown</c>.</summary>
         internal const string ContentionStartEndDurationNs = "clr_diagnostics_event.contention.startend_duration_ns";
 
         /// <summary>Counter. Tags: <c>gc_gen</c>, <c>gc_type</c>, and <c>gc_reason</c>.</summary>

--- a/src/ClrProfiler.DatadogTracing/MetricNames.cs
+++ b/src/ClrProfiler.DatadogTracing/MetricNames.cs
@@ -26,7 +26,7 @@ internal static class MetricNames
         /// <summary>Counter incremented by the aggregated contention count. Tags: <c>contention_type:0|1|unknown</c>.</summary>
         internal const string ContentionStartEndCount = "clr_diagnostics_event.contention.startend_count";
 
-        /// <summary>Gauge of average contention duration in nanoseconds. Tags: <c>contention_type:0|1|unknown</c>.</summary>
+        /// <summary>Gauge of the latest contention duration in nanoseconds. Tags: <c>contention_type:0|1|unknown</c>.</summary>
         internal const string ContentionStartEndDurationNs = "clr_diagnostics_event.contention.startend_duration_ns";
 
         /// <summary>Counter. Tags: <c>gc_gen</c>, <c>gc_type</c>, and <c>gc_reason</c>.</summary>

--- a/src/ClrProfiler.DatadogTracing/MetricNames.cs
+++ b/src/ClrProfiler.DatadogTracing/MetricNames.cs
@@ -26,8 +26,11 @@ internal static class MetricNames
         /// <summary>Counter incremented by the aggregated contention count. Tags: <c>contention_type:0|1|unknown</c>.</summary>
         internal const string ContentionStartEndCount = "clr_diagnostics_event.contention.startend_count";
 
-        /// <summary>Gauge of the latest contention duration in nanoseconds. Tags: <c>contention_type:0|1|unknown</c>.</summary>
+        /// <summary>Gauge of the longest contention duration in nanoseconds within the aggregation window. Tags: <c>contention_type:0|1|unknown</c>.</summary>
         internal const string ContentionStartEndDurationNs = "clr_diagnostics_event.contention.startend_duration_ns";
+
+        /// <summary>Counter incremented by the total contention duration in nanoseconds. Divide by <see cref="ContentionStartEndCount"/> for the mean. Tags: <c>contention_type:0|1|unknown</c>.</summary>
+        internal const string ContentionStartEndDurationNsSum = "clr_diagnostics_event.contention.startend_duration_ns_sum";
 
         /// <summary>Counter. Tags: <c>gc_gen</c>, <c>gc_type</c>, and <c>gc_reason</c>.</summary>
         internal const string GcStartEndCount = "clr_diagnostics_event.gc.startend_count";
@@ -54,6 +57,7 @@ internal static class MetricNames
         [
             ContentionStartEndCount,
             ContentionStartEndDurationNs,
+            ContentionStartEndDurationNsSum,
             GcStartEndCount,
             GcStartEndDurationMs,
             GcSuspendObjectCount,

--- a/src/ClrProfiler.DatadogTracing/MetricNames.cs
+++ b/src/ClrProfiler.DatadogTracing/MetricNames.cs
@@ -26,11 +26,17 @@ internal static class MetricNames
         /// <summary>Counter incremented by the aggregated contention count. Tags: <c>contention_type:0|1|unknown</c>.</summary>
         internal const string ContentionStartEndCount = "clr_diagnostics_event.contention.startend_count";
 
-        /// <summary>Gauge of the longest contention duration in nanoseconds within the aggregation window. Tags: <c>contention_type:0|1|unknown</c>.</summary>
-        internal const string ContentionStartEndDurationNs = "clr_diagnostics_event.contention.startend_duration_ns";
-
-        /// <summary>Counter incremented by the total contention duration in nanoseconds. Divide by <see cref="ContentionStartEndCount"/> for the mean. Tags: <c>contention_type:0|1|unknown</c>.</summary>
+        /// <summary>Counter incremented by the total contention duration in nanoseconds. Divide by <see cref="ContentionStartEndCount"/> for the mean duration. Tags: <c>contention_type:0|1|unknown</c>.</summary>
         internal const string ContentionStartEndDurationNsSum = "clr_diagnostics_event.contention.startend_duration_ns_sum";
+
+        /// <summary>
+        /// Histogram of the longest contention duration in nanoseconds per aggregation window. Read
+        /// the <c>.max</c> series: the maximum of the submitted window maxima is the true maximum for
+        /// the flush interval. The <c>.avg</c>, <c>.count</c>, and percentile series describe window
+        /// maxima rather than individual contentions, so they are not meaningful as durations.
+        /// Tags: <c>contention_type:0|1|unknown</c>.
+        /// </summary>
+        internal const string ContentionStartEndDurationNsMax = "clr_diagnostics_event.contention.startend_duration_ns_max";
 
         /// <summary>Counter. Tags: <c>gc_gen</c>, <c>gc_type</c>, and <c>gc_reason</c>.</summary>
         internal const string GcStartEndCount = "clr_diagnostics_event.gc.startend_count";
@@ -56,8 +62,8 @@ internal static class MetricNames
         private static readonly string[] Values =
         [
             ContentionStartEndCount,
-            ContentionStartEndDurationNs,
             ContentionStartEndDurationNsSum,
+            ContentionStartEndDurationNsMax,
             GcStartEndCount,
             GcStartEndDurationMs,
             GcSuspendObjectCount,

--- a/src/ClrProfiler/EventListeners/ContentionEventListener.cs
+++ b/src/ClrProfiler/EventListeners/ContentionEventListener.cs
@@ -14,12 +14,21 @@ namespace ClrProfiler.EventListeners;
 public class ContentionEventListener : ProfileEventListenerBase, IChannelReader
 {
     private const int ContentionFlagCount = byte.MaxValue + 1;
+    /// <summary>Picoseconds per nanosecond. Durations accumulate as whole picoseconds.</summary>
+    private const double PicosecondsPerNanosecond = 1000D;
+    /// <summary>
+    /// Upper bound for a single event's contribution, roughly 2.5 hours. Real contention is
+    /// orders of magnitude shorter; the cap only exists so a malformed payload cannot push the
+    /// accumulators toward overflow, and it takes 1024 capped events in one window to get there.
+    /// </summary>
+    private const long MaxDurationPicoseconds = long.MaxValue / 1024;
 
     private readonly Channel<bool> _flushSignal;
     private readonly Func<ContentionEventStatistics, Task> _onEventEmit;
     private readonly Action<Exception> _onEventError;
     private readonly long[] _counts = new long[ContentionFlagCount];
-    private readonly long[] _durationBits = new long[ContentionFlagCount];
+    private readonly long[] _durationSumPs = new long[ContentionFlagCount];
+    private readonly long[] _durationMaxPs = new long[ContentionFlagCount];
     private readonly long[] _times = new long[ContentionFlagCount];
     private readonly long[] _activeFlags = new long[ContentionFlagCount / 64];
 
@@ -61,12 +70,61 @@ public class ContentionEventListener : ProfileEventListenerBase, IChannelReader
 
     private void Aggregate(long time, byte flag, double durationNs)
     {
-        Interlocked.Exchange(ref _durationBits[flag], BitConverter.DoubleToInt64Bits(durationNs));
-        Interlocked.Exchange(ref _times[flag], time);
+        var durationPs = ToPicoseconds(durationNs);
+
+        // Duration and timestamp are folded in before the count is incremented. The reader gates a
+        // flush on a non-zero count, so this order can only ever attribute a duration to the flush
+        // before its own count, never drop it. Incrementing first would let a duration strand until
+        // the next event for the same flag arrives.
+        Interlocked.Add(ref _durationSumPs[flag], durationPs);
+        InterlockedMax(ref _durationMaxPs[flag], durationPs);
+        InterlockedMax(ref _times[flag], time);
         if (Interlocked.Increment(ref _counts[flag]) == 1)
         {
             Interlocked.Or(ref _activeFlags[flag / 64], 1L << (flag % 64));
             _flushSignal.Writer.TryWrite(true);
+        }
+    }
+
+    /// <summary>
+    /// Converts a payload duration to whole picoseconds so the per-event fold stays a single
+    /// lock-free add. Accumulating the sum as a double would need a compare-exchange loop, which
+    /// spins on exactly the path that is by definition already contended. Picoseconds keep the
+    /// values the runtime reports exact while leaving the accumulator far from overflow.
+    /// Non-finite and negative payloads contribute nothing rather than corrupting the sum.
+    /// </summary>
+    private static long ToPicoseconds(double durationNs)
+    {
+        if (!double.IsFinite(durationNs) || durationNs <= 0D)
+        {
+            return 0L;
+        }
+
+        var picoseconds = durationNs * PicosecondsPerNanosecond;
+        if (picoseconds >= MaxDurationPicoseconds)
+        {
+            return MaxDurationPicoseconds;
+        }
+
+        return (long)Math.Round(picoseconds, MidpointRounding.AwayFromZero);
+    }
+
+    /// <summary>
+    /// Raises <paramref name="location"/> to <paramref name="value"/> when it is larger. The loop
+    /// only retries when a concurrent writer also raised the value, so it is bounded by the number
+    /// of increases rather than by the number of writers.
+    /// </summary>
+    private static void InterlockedMax(ref long location, long value)
+    {
+        var current = Volatile.Read(ref location);
+        while (current < value)
+        {
+            var observed = Interlocked.CompareExchange(ref location, value, current);
+            if (observed == current)
+            {
+                return;
+            }
+            current = observed;
         }
     }
 
@@ -150,11 +208,23 @@ public class ContentionEventListener : ProfileEventListenerBase, IChannelReader
                             var count = Interlocked.Exchange(ref _counts[flag], 0);
                             if (count == 0)
                             {
+                                // A producer sets the active bit before incrementing the count, so a
+                                // bit can outlive the flush that already drained it. Leaving the
+                                // duration accumulators alone here is what lets a duration folded in
+                                // just before that flush be reported by the next one.
                                 continue;
                             }
-                            var durationBits = Volatile.Read(ref _durationBits[flag]);
+                            var durationSumPs = Interlocked.Exchange(ref _durationSumPs[flag], 0);
+                            var durationMaxPs = Interlocked.Exchange(ref _durationMaxPs[flag], 0);
+                            // Read, not reset: this is the newest timestamp seen for the flag and must
+                            // not regress to zero for a flush whose event was counted after a reset.
                             var time = Volatile.Read(ref _times[flag]);
-                            var value = new ContentionEventStatistics(time, (byte)flag, BitConverter.Int64BitsToDouble(durationBits), count);
+                            var value = new ContentionEventStatistics(
+                                time,
+                                (byte)flag,
+                                count,
+                                durationSumPs / PicosecondsPerNanosecond,
+                                durationMaxPs / PicosecondsPerNanosecond);
                             try
                             {
                                 await _onEventEmit.Invoke(value);

--- a/src/ClrProfiler/EventListeners/ContentionEventListener.cs
+++ b/src/ClrProfiler/EventListeners/ContentionEventListener.cs
@@ -23,7 +23,15 @@ public class ContentionEventListener : ProfileEventListenerBase, IChannelReader
     /// </summary>
     private const long MaxDurationPicoseconds = long.MaxValue / 1024;
 
+    /// <summary>
+    /// How many <see cref="Stop"/>-sealed aggregates can wait for a reader. One entry per flag per
+    /// stop, so this only fills if the listener is stopped many times over with no reader draining,
+    /// in which case the oldest sealed values are the ones worth keeping.
+    /// </summary>
+    private const int SealedAggregateCapacity = 64;
+
     private readonly Channel<bool> _flushSignal;
+    private readonly Channel<ContentionEventStatistics> _sealedAggregates;
     private readonly Func<ContentionEventStatistics, Task> _onEventEmit;
     private readonly Action<Exception> _onEventError;
     private readonly long[] _counts = new long[ContentionFlagCount];
@@ -43,6 +51,12 @@ public class ContentionEventListener : ProfileEventListenerBase, IChannelReader
             FullMode = BoundedChannelFullMode.DropWrite,
         };
         _flushSignal = Channel.CreateBounded<bool>(channelOption);
+        _sealedAggregates = Channel.CreateBounded<ContentionEventStatistics>(new BoundedChannelOptions(SealedAggregateCapacity)
+        {
+            SingleReader = true,
+            SingleWriter = false,
+            FullMode = BoundedChannelFullMode.DropWrite,
+        });
     }
 
     public override void EventCreatedHandler(EventWrittenEventArgs eventData)
@@ -128,6 +142,86 @@ public class ContentionEventListener : ProfileEventListenerBase, IChannelReader
         }
     }
 
+    /// <summary>
+    /// Stops the listener and seals whatever is still aggregated so it is delivered as its own
+    /// value.
+    /// </summary>
+    /// <remarks>
+    /// Without this, a burst that was observed but not yet dispatched stays in the accumulators and
+    /// is folded into the first events that arrive after <see cref="ProfileEventListenerBase.Restart"/>,
+    /// reporting old contention under a post-restart timestamp. Sealing happens synchronously here,
+    /// so by the time this returns the accumulators are empty and nothing can merge across the
+    /// boundary.
+    /// </remarks>
+    public override void Stop()
+    {
+        base.Stop();
+
+        var sealedAny = false;
+        for (var wordIndex = 0; wordIndex < _activeFlags.Length; wordIndex++)
+        {
+            var activeFlags = (ulong)Interlocked.Exchange(ref _activeFlags[wordIndex], 0);
+            while (activeFlags != 0)
+            {
+                var bitIndex = BitOperations.TrailingZeroCount(activeFlags);
+                var flag = (wordIndex * 64) + bitIndex;
+                activeFlags &= activeFlags - 1;
+
+                if (TryTakeAggregate(flag, out var value))
+                {
+                    sealedAny |= _sealedAggregates.Writer.TryWrite(value);
+                }
+            }
+        }
+
+        if (sealedAny)
+        {
+            _flushSignal.Writer.TryWrite(true);
+        }
+    }
+
+    /// <summary>
+    /// Takes everything aggregated for <paramref name="flag"/> and resets it for the next window.
+    /// Returns <see langword="false"/> when nothing was counted.
+    /// </summary>
+    private bool TryTakeAggregate(int flag, out ContentionEventStatistics value)
+    {
+        var count = Interlocked.Exchange(ref _counts[flag], 0);
+        if (count == 0)
+        {
+            // A producer sets the active bit before incrementing the count, so a bit can outlive
+            // the flush that already drained it. Leaving the duration accumulators alone here is
+            // what lets a duration folded in just before that flush be reported by the next one.
+            value = default;
+            return false;
+        }
+
+        var durationSumPs = Interlocked.Exchange(ref _durationSumPs[flag], 0);
+        var durationMaxPs = Interlocked.Exchange(ref _durationMaxPs[flag], 0);
+        // Read, not reset: this is the newest timestamp seen for the flag and must not regress to
+        // zero for a window whose event was counted after a reset.
+        var time = Volatile.Read(ref _times[flag]);
+        value = new ContentionEventStatistics(
+            time,
+            (byte)flag,
+            count,
+            durationSumPs / PicosecondsPerNanosecond,
+            durationMaxPs / PicosecondsPerNanosecond);
+        return true;
+    }
+
+    private async Task EmitAsync(ContentionEventStatistics value)
+    {
+        try
+        {
+            await _onEventEmit.Invoke(value);
+        }
+        catch (Exception ex)
+        {
+            _onEventError.Invoke(ex);
+        }
+    }
+
     private static byte ReadRequiredByte(IReadOnlyList<object?>? payload, int index)
     {
         if (payload is null || (uint)index >= (uint)payload.Count)
@@ -196,6 +290,13 @@ public class ContentionEventListener : ProfileEventListenerBase, IChannelReader
             {
                 while (_flushSignal.Reader.TryRead(out _))
                 {
+                    // Aggregates sealed by Stop come first so they keep their own timestamp and are
+                    // never reported after work that arrived on a later Restart.
+                    while (_sealedAggregates.Reader.TryRead(out var sealedValue))
+                    {
+                        await EmitAsync(sealedValue);
+                    }
+
                     for (var wordIndex = 0; wordIndex < _activeFlags.Length; wordIndex++)
                     {
                         var activeFlags = (ulong)Interlocked.Exchange(ref _activeFlags[wordIndex], 0);
@@ -205,33 +306,9 @@ public class ContentionEventListener : ProfileEventListenerBase, IChannelReader
                             var flag = (wordIndex * 64) + bitIndex;
                             activeFlags &= activeFlags - 1;
 
-                            var count = Interlocked.Exchange(ref _counts[flag], 0);
-                            if (count == 0)
+                            if (TryTakeAggregate(flag, out var value))
                             {
-                                // A producer sets the active bit before incrementing the count, so a
-                                // bit can outlive the flush that already drained it. Leaving the
-                                // duration accumulators alone here is what lets a duration folded in
-                                // just before that flush be reported by the next one.
-                                continue;
-                            }
-                            var durationSumPs = Interlocked.Exchange(ref _durationSumPs[flag], 0);
-                            var durationMaxPs = Interlocked.Exchange(ref _durationMaxPs[flag], 0);
-                            // Read, not reset: this is the newest timestamp seen for the flag and must
-                            // not regress to zero for a flush whose event was counted after a reset.
-                            var time = Volatile.Read(ref _times[flag]);
-                            var value = new ContentionEventStatistics(
-                                time,
-                                (byte)flag,
-                                count,
-                                durationSumPs / PicosecondsPerNanosecond,
-                                durationMaxPs / PicosecondsPerNanosecond);
-                            try
-                            {
-                                await _onEventEmit.Invoke(value);
-                            }
-                            catch (Exception ex)
-                            {
-                                _onEventError.Invoke(ex);
+                                await EmitAsync(value);
                             }
                         }
                     }

--- a/src/ClrProfiler/EventListeners/ContentionEventListener.cs
+++ b/src/ClrProfiler/EventListeners/ContentionEventListener.cs
@@ -18,8 +18,10 @@ public class ContentionEventListener : ProfileEventListenerBase, IChannelReader
     private readonly Channel<bool> _flushSignal;
     private readonly Func<ContentionEventStatistics, Task> _onEventEmit;
     private readonly Action<Exception> _onEventError;
-    private readonly AggregationBuffer[] _aggregationBuffers = [new(), new()];
-    private int _activeBufferIndex;
+    private readonly long[] _counts = new long[ContentionFlagCount];
+    private readonly long[] _durationBits = new long[ContentionFlagCount];
+    private readonly long[] _times = new long[ContentionFlagCount];
+    private readonly long[] _activeFlags = new long[ContentionFlagCount / 64];
 
     public ContentionEventListener(Func<ContentionEventStatistics, Task> onEventEmit, Action<Exception> onEventError) : base("Microsoft-Windows-DotNETRuntime", EventLevel.Informational, ClrRuntimeEventKeywords.Contention)
     {
@@ -59,21 +61,12 @@ public class ContentionEventListener : ProfileEventListenerBase, IChannelReader
 
     private void Aggregate(long time, byte flag, double durationNs)
     {
-        while (true)
+        Interlocked.Exchange(ref _durationBits[flag], BitConverter.DoubleToInt64Bits(durationNs));
+        Interlocked.Exchange(ref _times[flag], time);
+        if (Interlocked.Increment(ref _counts[flag]) == 1)
         {
-            var bufferIndex = Volatile.Read(ref _activeBufferIndex);
-            var buffer = _aggregationBuffers[bufferIndex];
-            Interlocked.Increment(ref buffer.Writers);
-            if (bufferIndex != Volatile.Read(ref _activeBufferIndex))
-            {
-                Interlocked.Decrement(ref buffer.Writers);
-                continue;
-            }
-
-            buffer.Add(time, flag, durationNs);
-            Interlocked.Decrement(ref buffer.Writers);
+            Interlocked.Or(ref _activeFlags[flag / 64], 1L << (flag % 64));
             _flushSignal.Writer.TryWrite(true);
-            return;
         }
     }
 
@@ -145,27 +138,22 @@ public class ContentionEventListener : ProfileEventListenerBase, IChannelReader
             {
                 while (_flushSignal.Reader.TryRead(out _))
                 {
-                    var bufferIndex = Interlocked.Exchange(ref _activeBufferIndex, 1 - Volatile.Read(ref _activeBufferIndex));
-                    var buffer = _aggregationBuffers[bufferIndex];
-                    var spinWait = new SpinWait();
-                    while (Volatile.Read(ref buffer.Writers) != 0)
+                    for (var wordIndex = 0; wordIndex < _activeFlags.Length; wordIndex++)
                     {
-                        cancellationToken.ThrowIfCancellationRequested();
-                        spinWait.SpinOnce();
-                    }
-
-                    for (var wordIndex = 0; wordIndex < buffer.ActiveFlags.Length; wordIndex++)
-                    {
-                        var activeFlags = (ulong)Interlocked.Exchange(ref buffer.ActiveFlags[wordIndex], 0);
+                        var activeFlags = (ulong)Interlocked.Exchange(ref _activeFlags[wordIndex], 0);
                         while (activeFlags != 0)
                         {
                             var bitIndex = BitOperations.TrailingZeroCount(activeFlags);
                             var flag = (wordIndex * 64) + bitIndex;
                             activeFlags &= activeFlags - 1;
 
-                            var count = Interlocked.Exchange(ref buffer.Counts[flag], 0);
-                            var durationBits = Interlocked.Exchange(ref buffer.DurationBits[flag], 0);
-                            var time = Interlocked.Exchange(ref buffer.Times[flag], 0);
+                            var count = Interlocked.Exchange(ref _counts[flag], 0);
+                            if (count == 0)
+                            {
+                                continue;
+                            }
+                            var durationBits = Volatile.Read(ref _durationBits[flag]);
+                            var time = Volatile.Read(ref _times[flag]);
                             var value = new ContentionEventStatistics(time, (byte)flag, BitConverter.Int64BitsToDouble(durationBits), count);
                             try
                             {
@@ -182,39 +170,6 @@ public class ContentionEventListener : ProfileEventListenerBase, IChannelReader
         }
         catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
         {
-        }
-    }
-
-    private sealed class AggregationBuffer
-    {
-        internal readonly long[] Counts = new long[ContentionFlagCount];
-        internal readonly long[] DurationBits = new long[ContentionFlagCount];
-        internal readonly long[] Times = new long[ContentionFlagCount];
-        internal readonly long[] ActiveFlags = new long[ContentionFlagCount / 64];
-        internal int Writers;
-
-        internal void Add(long time, byte flag, double durationNs)
-        {
-            AddDouble(ref DurationBits[flag], durationNs);
-            Interlocked.Exchange(ref Times[flag], time);
-            Interlocked.Increment(ref Counts[flag]);
-            Interlocked.Or(ref ActiveFlags[flag / 64], 1L << (flag % 64));
-        }
-
-        private static void AddDouble(ref long location, double value)
-        {
-            var currentBits = Volatile.Read(ref location);
-            while (true)
-            {
-                var current = BitConverter.Int64BitsToDouble(currentBits);
-                var nextBits = BitConverter.DoubleToInt64Bits(current + value);
-                var observedBits = Interlocked.CompareExchange(ref location, nextBits, currentBits);
-                if (observedBits == currentBits)
-                {
-                    return;
-                }
-                currentBits = observedBits;
-            }
         }
     }
 }

--- a/src/ClrProfiler/EventListeners/ContentionEventListener.cs
+++ b/src/ClrProfiler/EventListeners/ContentionEventListener.cs
@@ -1,6 +1,7 @@
 using ClrProfiler.Statistics;
 using System.Diagnostics.Tracing;
 using System.Globalization;
+using System.Numerics;
 using System.Threading.Channels;
 
 namespace ClrProfiler.EventListeners;
@@ -12,21 +13,25 @@ namespace ClrProfiler.EventListeners;
 /// </summary>
 public class ContentionEventListener : ProfileEventListenerBase, IChannelReader
 {
-    private readonly Channel<ContentionEventStatistics> _channel;
+    private const int ContentionFlagCount = byte.MaxValue + 1;
+
+    private readonly Channel<bool> _flushSignal;
     private readonly Func<ContentionEventStatistics, Task> _onEventEmit;
     private readonly Action<Exception> _onEventError;
+    private readonly AggregationBuffer[] _aggregationBuffers = [new(), new()];
+    private int _activeBufferIndex;
 
     public ContentionEventListener(Func<ContentionEventStatistics, Task> onEventEmit, Action<Exception> onEventError) : base("Microsoft-Windows-DotNETRuntime", EventLevel.Informational, ClrRuntimeEventKeywords.Contention)
     {
         _onEventEmit = onEventEmit;
         _onEventError = onEventError;
-        var channelOption = new BoundedChannelOptions(50)
+        var channelOption = new BoundedChannelOptions(1)
         {
             SingleReader = true,
-            SingleWriter = true,
-            FullMode = BoundedChannelFullMode.DropOldest,
+            SingleWriter = false,
+            FullMode = BoundedChannelFullMode.DropWrite,
         };
-        _channel = Channel.CreateBounded<ContentionEventStatistics>(channelOption);
+        _flushSignal = Channel.CreateBounded<bool>(channelOption);
     }
 
     public override void EventCreatedHandler(EventWrittenEventArgs eventData)
@@ -43,15 +48,32 @@ public class ContentionEventListener : ProfileEventListenerBase, IChannelReader
                 long time = timeStamp.Ticks;
                 var flag = ReadRequiredByte(payload, 0);
                 var durationNs = ReadRequiredDouble(payload, 2);
-                var stat = new ContentionEventStatistics(time, flag, durationNs);
-
-                // write to channel
-                _channel.Writer.TryWrite(stat);
+                Aggregate(time, flag, durationNs);
             }
         }
         catch (Exception ex)
         {
             _onEventError?.Invoke(ex);
+        }
+    }
+
+    private void Aggregate(long time, byte flag, double durationNs)
+    {
+        while (true)
+        {
+            var bufferIndex = Volatile.Read(ref _activeBufferIndex);
+            var buffer = _aggregationBuffers[bufferIndex];
+            Interlocked.Increment(ref buffer.Writers);
+            if (bufferIndex != Volatile.Read(ref _activeBufferIndex))
+            {
+                Interlocked.Decrement(ref buffer.Writers);
+                continue;
+            }
+
+            buffer.Add(time, flag, durationNs);
+            Interlocked.Decrement(ref buffer.Writers);
+            _flushSignal.Writer.TryWrite(true);
+            return;
         }
     }
 
@@ -119,19 +141,40 @@ public class ContentionEventListener : ProfileEventListenerBase, IChannelReader
         try
         {
             // Keep the reader alive across Stop/Restart. Cancellation owns its lifetime.
-            while (await _channel.Reader.WaitToReadAsync(cancellationToken))
+            while (await _flushSignal.Reader.WaitToReadAsync(cancellationToken))
             {
-                while (_channel.Reader.TryRead(out var value))
+                while (_flushSignal.Reader.TryRead(out _))
                 {
-                    if (_onEventEmit != null)
+                    var bufferIndex = Interlocked.Exchange(ref _activeBufferIndex, 1 - Volatile.Read(ref _activeBufferIndex));
+                    var buffer = _aggregationBuffers[bufferIndex];
+                    var spinWait = new SpinWait();
+                    while (Volatile.Read(ref buffer.Writers) != 0)
                     {
-                        try
+                        cancellationToken.ThrowIfCancellationRequested();
+                        spinWait.SpinOnce();
+                    }
+
+                    for (var wordIndex = 0; wordIndex < buffer.ActiveFlags.Length; wordIndex++)
+                    {
+                        var activeFlags = (ulong)Interlocked.Exchange(ref buffer.ActiveFlags[wordIndex], 0);
+                        while (activeFlags != 0)
                         {
-                            await _onEventEmit.Invoke(value);
-                        }
-                        catch (Exception ex)
-                        {
-                            _onEventError.Invoke(ex);
+                            var bitIndex = BitOperations.TrailingZeroCount(activeFlags);
+                            var flag = (wordIndex * 64) + bitIndex;
+                            activeFlags &= activeFlags - 1;
+
+                            var count = Interlocked.Exchange(ref buffer.Counts[flag], 0);
+                            var durationBits = Interlocked.Exchange(ref buffer.DurationBits[flag], 0);
+                            var time = Interlocked.Exchange(ref buffer.Times[flag], 0);
+                            var value = new ContentionEventStatistics(time, (byte)flag, BitConverter.Int64BitsToDouble(durationBits), count);
+                            try
+                            {
+                                await _onEventEmit.Invoke(value);
+                            }
+                            catch (Exception ex)
+                            {
+                                _onEventError.Invoke(ex);
+                            }
                         }
                     }
                 }
@@ -139,6 +182,39 @@ public class ContentionEventListener : ProfileEventListenerBase, IChannelReader
         }
         catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
         {
+        }
+    }
+
+    private sealed class AggregationBuffer
+    {
+        internal readonly long[] Counts = new long[ContentionFlagCount];
+        internal readonly long[] DurationBits = new long[ContentionFlagCount];
+        internal readonly long[] Times = new long[ContentionFlagCount];
+        internal readonly long[] ActiveFlags = new long[ContentionFlagCount / 64];
+        internal int Writers;
+
+        internal void Add(long time, byte flag, double durationNs)
+        {
+            AddDouble(ref DurationBits[flag], durationNs);
+            Interlocked.Exchange(ref Times[flag], time);
+            Interlocked.Increment(ref Counts[flag]);
+            Interlocked.Or(ref ActiveFlags[flag / 64], 1L << (flag % 64));
+        }
+
+        private static void AddDouble(ref long location, double value)
+        {
+            var currentBits = Volatile.Read(ref location);
+            while (true)
+            {
+                var current = BitConverter.Int64BitsToDouble(currentBits);
+                var nextBits = BitConverter.DoubleToInt64Bits(current + value);
+                var observedBits = Interlocked.CompareExchange(ref location, nextBits, currentBits);
+                if (observedBits == currentBits)
+                {
+                    return;
+                }
+                currentBits = observedBits;
+            }
         }
     }
 }

--- a/src/ClrProfiler/Statistics/ContentionEventStatistics.cs
+++ b/src/ClrProfiler/Statistics/ContentionEventStatistics.cs
@@ -2,16 +2,34 @@ using System.Diagnostics.CodeAnalysis;
 
 namespace ClrProfiler.Statistics;
 
-public readonly struct ContentionEventStatistics(long time, byte flag, double durationNs) : IEquatable<ContentionEventStatistics>
+public readonly struct ContentionEventStatistics : IEquatable<ContentionEventStatistics>
 {
-    public readonly long Time = time;
+    public readonly long Time;
     /// <summary>
     /// see - https://learn.microsoft.com/en-us/dotnet/framework/performance/contention-etw-events
     /// 0 : managed.
     /// 1 : native
     /// </summary>
-    public readonly byte Flag = flag;
-    public readonly double DurationNs = durationNs;
+    public readonly byte Flag;
+    /// <summary>Total duration in nanoseconds across the aggregated contention events.</summary>
+    public readonly double DurationNs;
+    /// <summary>Number of contention events represented by this value.</summary>
+    public readonly long Count;
+    /// <summary>Average duration in nanoseconds per represented contention event.</summary>
+    public double AverageDurationNs => Count > 0 ? DurationNs / Count : 0;
+
+    public ContentionEventStatistics(long time, byte flag, double durationNs)
+        : this(time, flag, durationNs, 1)
+    {
+    }
+
+    public ContentionEventStatistics(long time, byte flag, double durationNs, long count)
+    {
+        Time = time;
+        Flag = flag;
+        DurationNs = durationNs;
+        Count = count;
+    }
 
     public override bool Equals(object? obj)
     {
@@ -23,12 +41,13 @@ public readonly struct ContentionEventStatistics(long time, byte flag, double du
     {
         return Time == other.Time
             && Flag == other.Flag
-            && DurationNs == other.DurationNs;
+            && DurationNs == other.DurationNs
+            && Count == other.Count;
     }
 
     public override int GetHashCode()
     {
-        return HashCode.Combine(Time, Flag, DurationNs);
+        return HashCode.Combine(Time, Flag, DurationNs, Count);
     }
 
     public static bool operator ==(ContentionEventStatistics left, ContentionEventStatistics right)

--- a/src/ClrProfiler/Statistics/ContentionEventStatistics.cs
+++ b/src/ClrProfiler/Statistics/ContentionEventStatistics.cs
@@ -4,6 +4,7 @@ namespace ClrProfiler.Statistics;
 
 public readonly struct ContentionEventStatistics : IEquatable<ContentionEventStatistics>
 {
+    /// <summary>Timestamp of the latest observed contention event for this flag.</summary>
     public readonly long Time;
     /// <summary>
     /// see - https://learn.microsoft.com/en-us/dotnet/framework/performance/contention-etw-events
@@ -11,12 +12,10 @@ public readonly struct ContentionEventStatistics : IEquatable<ContentionEventSta
     /// 1 : native
     /// </summary>
     public readonly byte Flag;
-    /// <summary>Total duration in nanoseconds across the aggregated contention events.</summary>
+    /// <summary>Latest observed contention duration in nanoseconds for this flag.</summary>
     public readonly double DurationNs;
     /// <summary>Number of contention events represented by this value.</summary>
     public readonly long Count;
-    /// <summary>Average duration in nanoseconds per represented contention event.</summary>
-    public double AverageDurationNs => Count > 0 ? DurationNs / Count : 0;
 
     public ContentionEventStatistics(long time, byte flag, double durationNs)
         : this(time, flag, durationNs, 1)

--- a/src/ClrProfiler/Statistics/ContentionEventStatistics.cs
+++ b/src/ClrProfiler/Statistics/ContentionEventStatistics.cs
@@ -2,9 +2,20 @@ using System.Diagnostics.CodeAnalysis;
 
 namespace ClrProfiler.Statistics;
 
+/// <summary>
+/// Contention events aggregated per contention flag over one delivery window.
+/// </summary>
+/// <remarks>
+/// A single value can represent many events, so the duration is exposed as a sum and a maximum
+/// rather than as one sample. A lone sample would be meaningless next to <see cref="Count"/>:
+/// during a burst the vast majority of samples are never observed by the reader.
+/// </remarks>
 public readonly struct ContentionEventStatistics : IEquatable<ContentionEventStatistics>
 {
-    /// <summary>Timestamp of the latest observed contention event for this flag.</summary>
+    /// <summary>
+    /// Timestamp of the newest contention event observed for this flag. The duration fields
+    /// summarize the whole window and are not tied to the event this timestamp came from.
+    /// </summary>
     public readonly long Time;
     /// <summary>
     /// see - https://learn.microsoft.com/en-us/dotnet/framework/performance/contention-etw-events
@@ -12,22 +23,29 @@ public readonly struct ContentionEventStatistics : IEquatable<ContentionEventSta
     /// 1 : native
     /// </summary>
     public readonly byte Flag;
-    /// <summary>Latest observed contention duration in nanoseconds for this flag.</summary>
-    public readonly double DurationNs;
     /// <summary>Number of contention events represented by this value.</summary>
     public readonly long Count;
+    /// <summary>Total contention duration in nanoseconds across the represented events.</summary>
+    public readonly double DurationNsSum;
+    /// <summary>Longest single contention duration in nanoseconds across the represented events.</summary>
+    public readonly double DurationNsMax;
 
+    /// <summary>Mean contention duration in nanoseconds, or 0 when nothing was aggregated.</summary>
+    public double DurationNsMean => Count == 0 ? 0D : DurationNsSum / Count;
+
+    /// <summary>Creates a value representing a single contention event.</summary>
     public ContentionEventStatistics(long time, byte flag, double durationNs)
-        : this(time, flag, durationNs, 1)
+        : this(time, flag, 1, durationNs, durationNs)
     {
     }
 
-    public ContentionEventStatistics(long time, byte flag, double durationNs, long count)
+    public ContentionEventStatistics(long time, byte flag, long count, double durationNsSum, double durationNsMax)
     {
         Time = time;
         Flag = flag;
-        DurationNs = durationNs;
         Count = count;
+        DurationNsSum = durationNsSum;
+        DurationNsMax = durationNsMax;
     }
 
     public override bool Equals(object? obj)
@@ -40,13 +58,14 @@ public readonly struct ContentionEventStatistics : IEquatable<ContentionEventSta
     {
         return Time == other.Time
             && Flag == other.Flag
-            && DurationNs == other.DurationNs
-            && Count == other.Count;
+            && Count == other.Count
+            && DurationNsSum == other.DurationNsSum
+            && DurationNsMax == other.DurationNsMax;
     }
 
     public override int GetHashCode()
     {
-        return HashCode.Combine(Time, Flag, DurationNs, Count);
+        return HashCode.Combine(Time, Flag, Count, DurationNsSum, DurationNsMax);
     }
 
     public static bool operator ==(ContentionEventStatistics left, ContentionEventStatistics right)

--- a/tests/CleProfiler.DatadogTracing.UnitTest/ContentionMetricWireFormatTest.cs
+++ b/tests/CleProfiler.DatadogTracing.UnitTest/ContentionMetricWireFormatTest.cs
@@ -1,0 +1,50 @@
+using ClrProfiler.Statistics;
+// The test namespace shadows the adapter namespace, so alias the static class explicitly.
+using Tracing = ClrProfiler.DatadogTracing.DatadogTracing;
+
+namespace CleProfiler.DatadogTracing.UnitTest;
+
+/// <summary>
+/// Guards the statsd metric type of every contention metric. The type decides how a value is
+/// aggregated over a flush interval, and the listener emits an aggregation window every time the
+/// reader drains, which is far more often than statsd flushes. A type that keeps only one
+/// submission per interval therefore discards almost every window.
+/// </summary>
+[NotInParallel(DogStatsdWireFixture.SerializationKey)]
+public class ContentionMetricWireFormatTest
+{
+    private static readonly TimeSpan MetricTimeout = TimeSpan.FromSeconds(30);
+
+    [Test]
+    [ClassDataSource<DogStatsdWireFixture>(Shared = SharedType.PerTestSession)]
+    public async Task ContentionEventStartEnd_EmitsTypesThatSurviveIntervalAggregation(DogStatsdWireFixture wire)
+    {
+        var cancellationToken = TestContext.Current!.Execution.CancellationToken;
+        var capture = wire.StartCapture();
+
+        Tracing.ContentionEventStartEnd(new ContentionEventStatistics(1, 0, 3, 90D, 40D));
+
+        var lines = await capture.WaitForAllAsync(
+            [
+                // Counters add up across submissions, so no aggregation window is lost.
+                "clr_diagnostics_event.contention.startend_count:3|c|",
+                "clr_diagnostics_event.contention.startend_duration_ns_sum:90|c|",
+                // Histogram, not gauge: the agent keeps the maximum across every submission in the
+                // interval, so per-window maxima compose into a true interval maximum.
+                "clr_diagnostics_event.contention.startend_duration_ns_max:40|h|",
+            ],
+            MetricTimeout,
+            cancellationToken);
+
+        var contentionLines = lines
+            .Where(x => x.Contains("clr_diagnostics_event.contention.", StringComparison.Ordinal))
+            .ToArray();
+
+        // A gauge would keep only the last window in a flush interval and discard the rest.
+        await Assert.That(contentionLines).DoesNotContain(x => x.Contains("|g|", StringComparison.Ordinal));
+        foreach (var line in contentionLines)
+        {
+            await Assert.That(line).Contains(DogStatsdWireFixture.ConstantTag);
+        }
+    }
+}

--- a/tests/CleProfiler.DatadogTracing.UnitTest/DatadogTracingUnitTest.cs
+++ b/tests/CleProfiler.DatadogTracing.UnitTest/DatadogTracingUnitTest.cs
@@ -1,5 +1,8 @@
 using ClrProfiler.DatadogTracing;
+using ClrProfiler.Statistics;
 using StatsdClient;
+// The test namespace shadows the adapter namespace, so alias the static class explicitly.
+using Tracing = ClrProfiler.DatadogTracing.DatadogTracing;
 
 namespace CleProfiler.DatadogTracing.UnitTest;
 
@@ -45,6 +48,11 @@ public class DatadogTracingUnitTest
         tracker.EnableTracker();
         tracker.StartTracker();
 
+        // Contention aggregates are emitted once per reader drain, which happens far more often than
+        // statsd flushes, so the statsd type has to survive many submissions per interval. Emitted
+        // here rather than in its own test because DogStatsd.Configure is process-global state.
+        Tracing.ContentionEventStartEnd(new ContentionEventStatistics(1, 0, 3, 90D, 40D));
+
         // Allocate and GC
         while (!complete)
         {
@@ -67,6 +75,15 @@ public class DatadogTracingUnitTest
         await Assert.That(list).Contains(x => x.Contains("clr_diagnostics_event.gc.suspend_duration_ms"));
         await Assert.That(list).Contains(x => x.Contains("gc_gen:2,gc_type:0,gc_reason:induced"));
         await Assert.That(list).Contains(x => x.Contains("gc_suspend_reason:gc"));
+
+        // Counters add up across submissions, so no aggregation window is lost.
+        await Assert.That(list).Contains(x => x.Contains("clr_diagnostics_event.contention.startend_count:3|c|"));
+        await Assert.That(list).Contains(x => x.Contains("clr_diagnostics_event.contention.startend_duration_ns_sum:90|c|"));
+        // Histogram, not gauge: the agent keeps the maximum across every submission in the interval,
+        // so per-window maxima compose into a true interval maximum. A gauge would keep only the last
+        // window and discard the rest.
+        await Assert.That(list).Contains(x => x.Contains("clr_diagnostics_event.contention.startend_duration_ns_max:40|h|"));
+        await Assert.That(list).DoesNotContain(x => x.Contains("clr_diagnostics_event.contention.") && x.Contains("|g|"));
 
         tracker.StopTracker();
         cts.Cancel();

--- a/tests/CleProfiler.DatadogTracing.UnitTest/DatadogTracingUnitTest.cs
+++ b/tests/CleProfiler.DatadogTracing.UnitTest/DatadogTracingUnitTest.cs
@@ -1,91 +1,52 @@
 using ClrProfiler.DatadogTracing;
-using ClrProfiler.Statistics;
-using StatsdClient;
-// The test namespace shadows the adapter namespace, so alias the static class explicitly.
-using Tracing = ClrProfiler.DatadogTracing.DatadogTracing;
 
 namespace CleProfiler.DatadogTracing.UnitTest;
 
-[NotInParallel]
+[NotInParallel(DogStatsdWireFixture.SerializationKey)]
 public class DatadogTracingUnitTest
 {
+    private static readonly TimeSpan MetricTimeout = TimeSpan.FromSeconds(30);
+
     [Test]
-    public async Task DatadogTracingGCUniTest()
+    [ClassDataSource<DogStatsdWireFixture>(Shared = SharedType.PerTestSession)]
+    public async Task GcEventMetrics_ReachTheAgentWithExpectedNamesAndTags(DogStatsdWireFixture wire)
     {
-        using var cts = new CancellationTokenSource();
-        var logger = TestHelpers.CreateLogger<DatadogTracingUnitTest>();
-        var host = "127.0.0.1";
-        var port = 8125;
-        var tag = "app:ClrProfiler.DatadogTracing.UnitTest";
-        var complete = false;
-        var list = new List<string>();
+        var cancellationToken = TestContext.Current!.Execution.CancellationToken;
+        var capture = wire.StartCapture();
 
-        // server
-        var server = new TestHelpers.UdpServer(host, port)
-        {
-            OnRecieveMessage = (_, text) =>
-            {
-                if (!text.StartsWith("datadog.dogstatsd"))
-                {
-                    list.Add(text);
-                }
-            }
-        };
-        var serverTask = Task.Run(async () => await server.ListenAsync(cts.Token), cts.Token);
-
-        // client
-        var dogstatsdConfig = new StatsdConfig
-        {
-            StatsdServerName = host,
-            StatsdPort = port,
-            ConstantTags = new[] { tag },
-        };
-        DogStatsd.Configure(dogstatsdConfig);
-
-        // enable clr tracker
         using var loggerFactory = TestHelpers.CreateLoggerFactory();
-        var tracker = new ClrTracker(loggerFactory);
+        using var tracker = new ClrTracker(loggerFactory);
         tracker.EnableTracker();
         tracker.StartTracker();
 
-        // Contention aggregates are emitted once per reader drain, which happens far more often than
-        // statsd flushes, so the statsd type has to survive many submissions per interval. Emitted
-        // here rather than in its own test because DogStatsd.Configure is process-global state.
-        Tracing.ContentionEventStartEnd(new ContentionEventStatistics(1, 0, 3, 90D, 40D));
-
-        // Allocate and GC
-        while (!complete)
+        string[] lines;
+        try
         {
-            TestHelpers.Allocate5K();
-            GC.Collect();
-            await Task.Delay(10);
-
-            if (list.Count >= 20)
-            {
-                complete = true;
-            }
+            // These metrics need real collections to happen, so keep allocating while waiting.
+            lines = await capture.WaitForAllAsync(
+                [
+                    "clr_diagnostics_event.gc.suspend_object_count",
+                    "clr_diagnostics_event.gc.suspend_duration_ms",
+                    "gc_gen:2,gc_type:0,gc_reason:induced",
+                    "gc_suspend_reason:gc",
+                ],
+                MetricTimeout,
+                cancellationToken,
+                static () =>
+                {
+                    TestHelpers.Allocate5K();
+                    GC.Collect();
+                    return Task.CompletedTask;
+                });
+        }
+        finally
+        {
+            tracker.StopTracker();
         }
 
-        //await Assert.That(output).IsEqualTo("clr_diagnostics_event.gc.startend_count:18|c|#app:ConsoleApp,gc_gen:2,gc_type:0,gc_reason:induced\nclr_diagnostics_event.gc.suspend_object_count:181|c|#app:ConsoleApp,gc_suspend_reason:gc\n");
-        foreach (var item in list)
+        foreach (var line in lines)
         {
-            await Assert.That(item).Contains(tag);
+            await Assert.That(line).Contains(DogStatsdWireFixture.ConstantTag);
         }
-        await Assert.That(list).Contains(x => x.Contains("clr_diagnostics_event.gc.suspend_object_count"));
-        await Assert.That(list).Contains(x => x.Contains("clr_diagnostics_event.gc.suspend_duration_ms"));
-        await Assert.That(list).Contains(x => x.Contains("gc_gen:2,gc_type:0,gc_reason:induced"));
-        await Assert.That(list).Contains(x => x.Contains("gc_suspend_reason:gc"));
-
-        // Counters add up across submissions, so no aggregation window is lost.
-        await Assert.That(list).Contains(x => x.Contains("clr_diagnostics_event.contention.startend_count:3|c|"));
-        await Assert.That(list).Contains(x => x.Contains("clr_diagnostics_event.contention.startend_duration_ns_sum:90|c|"));
-        // Histogram, not gauge: the agent keeps the maximum across every submission in the interval,
-        // so per-window maxima compose into a true interval maximum. A gauge would keep only the last
-        // window and discard the rest.
-        await Assert.That(list).Contains(x => x.Contains("clr_diagnostics_event.contention.startend_duration_ns_max:40|h|"));
-        await Assert.That(list).DoesNotContain(x => x.Contains("clr_diagnostics_event.contention.") && x.Contains("|g|"));
-
-        tracker.StopTracker();
-        cts.Cancel();
     }
 }

--- a/tests/CleProfiler.DatadogTracing.UnitTest/DogStatsdWireFixture.cs
+++ b/tests/CleProfiler.DatadogTracing.UnitTest/DogStatsdWireFixture.cs
@@ -1,0 +1,176 @@
+using StatsdClient;
+using System.Net;
+using System.Net.Sockets;
+using System.Text;
+using TUnit.Core.Interfaces;
+
+namespace CleProfiler.DatadogTracing.UnitTest;
+
+/// <summary>
+/// Owns the one DogStatsD configuration and the one listening socket for the whole test session,
+/// so wire-level tests can assert the statsd lines the adapters actually emit.
+/// </summary>
+/// <remarks>
+/// <see cref="DogStatsd.Configure"/> writes process-global static state. Calling it a second time
+/// in one process leaves metrics from the earlier configuration undeliverable, so a test waiting
+/// on them never completes. Wire-level tests therefore take this fixture instead of configuring
+/// DogStatsD themselves, and serialize on <see cref="SerializationKey"/> so their captures do not
+/// interleave. The socket binds port 0 and reports the assigned port, so a leaked process from an
+/// earlier run cannot make the next run fail to bind.
+/// </remarks>
+public sealed class DogStatsdWireFixture : IAsyncInitializer, IAsyncDisposable
+{
+    /// <summary>Apply as <c>[NotInParallel(DogStatsdWireFixture.SerializationKey)]</c> on every test class using this fixture.</summary>
+    public const string SerializationKey = "DogStatsdWire";
+
+    /// <summary>Constant tag attached to every metric this fixture receives.</summary>
+    public const string ConstantTag = "app:ClrProfiler.DatadogTracing.UnitTest";
+
+    private static readonly TimeSpan PollInterval = TimeSpan.FromMilliseconds(10);
+
+    private readonly List<string> _lines = [];
+    private readonly CancellationTokenSource _cts = new();
+    private UdpClient? _udp;
+    private Task? _listener;
+
+    /// <summary>Dynamically assigned port the configured DogStatsD client sends to.</summary>
+    public int Port { get; private set; }
+
+    public Task InitializeAsync()
+    {
+        _udp = new UdpClient(new IPEndPoint(IPAddress.Loopback, 0));
+        Port = ((IPEndPoint)_udp.Client.LocalEndPoint!).Port;
+        _listener = Task.Run(() => ReceiveLoopAsync(_cts.Token));
+
+        DogStatsd.Configure(new StatsdConfig
+        {
+            StatsdServerName = IPAddress.Loopback.ToString(),
+            StatsdPort = Port,
+            ConstantTags = [ConstantTag],
+        });
+
+        return Task.CompletedTask;
+    }
+
+    /// <summary>
+    /// Starts observing lines received from this point on, so a test never sees what an earlier
+    /// test produced on the shared socket.
+    /// </summary>
+    public WireCapture StartCapture()
+    {
+        lock (_lines)
+        {
+            return new WireCapture(this, _lines.Count);
+        }
+    }
+
+    internal string[] LinesFrom(int offset)
+    {
+        lock (_lines)
+        {
+            return offset >= _lines.Count ? [] : [.. _lines.GetRange(offset, _lines.Count - offset)];
+        }
+    }
+
+    internal static TimeSpan Poll => PollInterval;
+
+    private async Task ReceiveLoopAsync(CancellationToken cancellationToken)
+    {
+        try
+        {
+            while (!cancellationToken.IsCancellationRequested)
+            {
+                var result = await _udp!.ReceiveAsync(cancellationToken);
+                var text = Encoding.UTF8.GetString(result.Buffer);
+                // One datagram can carry several metrics, so split rather than treating the
+                // payload as a single line.
+                foreach (var line in text.Split('\n', StringSplitOptions.RemoveEmptyEntries))
+                {
+                    // The client reports its own delivery telemetry over the same socket.
+                    if (line.StartsWith("datadog.dogstatsd", StringComparison.Ordinal))
+                    {
+                        continue;
+                    }
+                    lock (_lines)
+                    {
+                        _lines.Add(line);
+                    }
+                }
+            }
+        }
+        catch (OperationCanceledException)
+        {
+        }
+        catch (ObjectDisposedException)
+        {
+        }
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        await _cts.CancelAsync();
+        _udp?.Dispose();
+        if (_listener is not null)
+        {
+            try
+            {
+                await _listener;
+            }
+            catch (OperationCanceledException)
+            {
+            }
+        }
+        _cts.Dispose();
+    }
+}
+
+/// <summary>Lines received on the shared socket since the capture was started.</summary>
+public sealed class WireCapture(DogStatsdWireFixture fixture, int offset)
+{
+    /// <summary>Snapshot of the statsd lines received so far.</summary>
+    public string[] Lines => fixture.LinesFrom(offset);
+
+    /// <summary>
+    /// Waits until every entry in <paramref name="requiredSubstrings"/> appears in some received
+    /// line, then returns the lines. Throws <see cref="TimeoutException"/> naming the substrings
+    /// that never arrived rather than blocking forever.
+    /// </summary>
+    /// <param name="produce">
+    /// Optional work to repeat while waiting, for metrics that need runtime activity to occur.
+    /// </param>
+    public async Task<string[]> WaitForAllAsync(
+        IReadOnlyList<string> requiredSubstrings,
+        TimeSpan timeout,
+        CancellationToken cancellationToken,
+        Func<Task>? produce = null)
+    {
+        using var deadline = new CancellationTokenSource(timeout);
+        while (true)
+        {
+            var lines = Lines;
+            var missing = requiredSubstrings
+                .Where(required => !Array.Exists(lines, line => line.Contains(required, StringComparison.Ordinal)))
+                .ToArray();
+            if (missing.Length == 0)
+            {
+                return lines;
+            }
+
+            cancellationToken.ThrowIfCancellationRequested();
+            if (deadline.IsCancellationRequested)
+            {
+                throw new TimeoutException(
+                    $"Timed out after {timeout.TotalSeconds:N0}s waiting for {missing.Length} statsd metric(s):{Environment.NewLine}" +
+                    $"  missing: {string.Join(Environment.NewLine + "           ", missing)}{Environment.NewLine}" +
+                    $"  received {lines.Length} line(s):{Environment.NewLine}" +
+                    (lines.Length == 0 ? "    (none)" : "    " + string.Join(Environment.NewLine + "    ", lines)));
+            }
+
+            if (produce is not null)
+            {
+                await produce();
+            }
+            await Task.Delay(DogStatsdWireFixture.Poll, cancellationToken);
+        }
+    }
+}

--- a/tests/CleProfiler.DatadogTracing.UnitTest/MetricNamesTest.cs
+++ b/tests/CleProfiler.DatadogTracing.UnitTest/MetricNamesTest.cs
@@ -11,8 +11,8 @@ public class MetricNamesTest
         string[] expected =
         [
             "clr_diagnostics_event.contention.startend_count",
-            "clr_diagnostics_event.contention.startend_duration_ns",
             "clr_diagnostics_event.contention.startend_duration_ns_sum",
+            "clr_diagnostics_event.contention.startend_duration_ns_max",
             "clr_diagnostics_event.gc.startend_count",
             "clr_diagnostics_event.gc.startend_duration_ms",
             "clr_diagnostics_event.gc.suspend_object_count",

--- a/tests/CleProfiler.DatadogTracing.UnitTest/MetricNamesTest.cs
+++ b/tests/CleProfiler.DatadogTracing.UnitTest/MetricNamesTest.cs
@@ -7,45 +7,57 @@ public class MetricNamesTest
     [Test]
     public async Task EventCatalog_ContainsEveryEmittedMetricOnce()
     {
-        var actual = string.Join('\n', MetricNames.Event.All.ToArray());
+        var actual = MetricNames.Event.All.ToArray();
+        string[] expected =
+        [
+            "clr_diagnostics_event.contention.startend_count",
+            "clr_diagnostics_event.contention.startend_duration_ns",
+            "clr_diagnostics_event.gc.startend_count",
+            "clr_diagnostics_event.gc.startend_duration_ms",
+            "clr_diagnostics_event.gc.suspend_object_count",
+            "clr_diagnostics_event.gc.suspend_duration_ms",
+            "clr_diagnostics_event.threadpool.available_workerthread_count",
+            "clr_diagnostics_event.threadpool.adjustment_avg_throughput",
+            "clr_diagnostics_event.threadpool.adjustment_new_workerthreads_count",
+        ];
 
-        await Assert.That(actual).IsEqualTo("""
-            clr_diagnostics_event.contention.startend_count
-            clr_diagnostics_event.contention.startend_duration_ns
-            clr_diagnostics_event.gc.startend_count
-            clr_diagnostics_event.gc.startend_duration_ms
-            clr_diagnostics_event.gc.suspend_object_count
-            clr_diagnostics_event.gc.suspend_duration_ms
-            clr_diagnostics_event.threadpool.available_workerthread_count
-            clr_diagnostics_event.threadpool.adjustment_avg_throughput
-            clr_diagnostics_event.threadpool.adjustment_new_workerthreads_count
-            """);
+        await Assert.That(actual.Length).IsEqualTo(expected.Length);
+        for (var i = 0; i < expected.Length; i++)
+        {
+            await Assert.That(actual[i]).IsEqualTo(expected[i]);
+        }
     }
 
     [Test]
     public async Task TimerCatalog_ContainsEveryEmittedMetricOnce()
     {
-        var actual = string.Join('\n', MetricNames.Timer.All.ToArray());
+        var actual = MetricNames.Timer.All.ToArray();
+        string[] expected =
+        [
+            "clr_diagnostics_timer.gc.heap_size_bytes",
+            "clr_diagnostics_timer.gc.total_allocation_bytes",
+            "clr_diagnostics_timer.gc.gc_count",
+            "clr_diagnostics_timer.gc.gc_size",
+            "clr_diagnostics_timer.gc.time_in_gc_percent",
+            "clr_diagnostics_timer.process.cpu",
+            "clr_diagnostics_timer.process.private_bytes",
+            "clr_diagnostics_timer.process.working_sets",
+            "clr_diagnostics_timer.thread.available_worker_threads",
+            "clr_diagnostics_timer.thread.available_completion_port_threads",
+            "clr_diagnostics_timer.thread.max_worker_threads",
+            "clr_diagnostics_timer.thread.max_completion_port_threads",
+            "clr_diagnostics_timer.thread.using_worker_threads",
+            "clr_diagnostics_timer.thread.using_completion_port_threads",
+            "clr_diagnostics_timer.thread.thread_count",
+            "clr_diagnostics_timer.thread.queue_length",
+            "clr_diagnostics_timer.thread.lock_contention_count",
+            "clr_diagnostics_timer.thread.completed_items_count",
+        ];
 
-        await Assert.That(actual).IsEqualTo("""
-            clr_diagnostics_timer.gc.heap_size_bytes
-            clr_diagnostics_timer.gc.total_allocation_bytes
-            clr_diagnostics_timer.gc.gc_count
-            clr_diagnostics_timer.gc.gc_size
-            clr_diagnostics_timer.gc.time_in_gc_percent
-            clr_diagnostics_timer.process.cpu
-            clr_diagnostics_timer.process.private_bytes
-            clr_diagnostics_timer.process.working_sets
-            clr_diagnostics_timer.thread.available_worker_threads
-            clr_diagnostics_timer.thread.available_completion_port_threads
-            clr_diagnostics_timer.thread.max_worker_threads
-            clr_diagnostics_timer.thread.max_completion_port_threads
-            clr_diagnostics_timer.thread.using_worker_threads
-            clr_diagnostics_timer.thread.using_completion_port_threads
-            clr_diagnostics_timer.thread.thread_count
-            clr_diagnostics_timer.thread.queue_length
-            clr_diagnostics_timer.thread.lock_contention_count
-            clr_diagnostics_timer.thread.completed_items_count
-            """);
+        await Assert.That(actual.Length).IsEqualTo(expected.Length);
+        for (var i = 0; i < expected.Length; i++)
+        {
+            await Assert.That(actual[i]).IsEqualTo(expected[i]);
+        }
     }
 }

--- a/tests/CleProfiler.DatadogTracing.UnitTest/MetricNamesTest.cs
+++ b/tests/CleProfiler.DatadogTracing.UnitTest/MetricNamesTest.cs
@@ -12,6 +12,7 @@ public class MetricNamesTest
         [
             "clr_diagnostics_event.contention.startend_count",
             "clr_diagnostics_event.contention.startend_duration_ns",
+            "clr_diagnostics_event.contention.startend_duration_ns_sum",
             "clr_diagnostics_event.gc.startend_count",
             "clr_diagnostics_event.gc.startend_duration_ms",
             "clr_diagnostics_event.gc.suspend_object_count",

--- a/tests/CleProfiler.DatadogTracing.UnitTest/MetricTagAllocationTest.cs
+++ b/tests/CleProfiler.DatadogTracing.UnitTest/MetricTagAllocationTest.cs
@@ -1,11 +1,27 @@
 using ClrProfiler.DatadogTracing;
 using ClrProfiler.Statistics;
 using Microsoft.Extensions.Logging;
+using System.Runtime.CompilerServices;
 
 namespace CleProfiler.DatadogTracing.UnitTest;
 
+/// <summary>
+/// Asserts that the metric projection hot paths allocate nothing once they are warm.
+/// </summary>
+/// <remarks>
+/// Every measured loop lives in its own <see cref="MethodImplOptions.AggressiveOptimization"/>
+/// method, and warmup runs the same method the measurement does. Without that, the loop starts as
+/// tier-0 code and the runtime swaps it mid-flight through an on-stack replacement transition,
+/// which allocates 24 bytes on the executing thread. Whether that transition lands in the warmup
+/// loop or inside the measurement window depends on how busy the runtime was when the test
+/// started, so it made these assertions depend on test execution order. AggressiveOptimization
+/// opts the loop out of tiered compilation, so it is fully optimized on the first call and never
+/// transitions. Verified: with the loop left tiered, the allocation reproduces at a fixed
+/// iteration even when the loop body is replaced by integer arithmetic.
+/// </remarks>
 public class MetricTagAllocationTest
 {
+    private const int WarmupIterations = 1_000;
     private const int Iterations = 10_000;
     private static readonly ILogger DisabledLogger = new DisabledLoggerImplementation();
     private static readonly Exception CallbackException = new InvalidOperationException("callback failed");
@@ -14,16 +30,10 @@ public class MetricTagAllocationTest
     [Test]
     public async Task LoggerGcEventStartEnd_WhenDebugDisabled_DoesNotAllocate()
     {
-        for (var i = 0; i < 1_000; i++)
-        {
-            LoggerTracing.GcEventStartEnd(Statistics, DisabledLogger);
-        }
+        LogGcEvents(WarmupIterations);
 
         var before = GC.GetAllocatedBytesForCurrentThread();
-        for (var i = 0; i < Iterations; i++)
-        {
-            LoggerTracing.GcEventStartEnd(Statistics, DisabledLogger);
-        }
+        LogGcEvents(Iterations);
         var allocatedBytes = GC.GetAllocatedBytesForCurrentThread() - before;
 
         Console.WriteLine($"Allocated bytes: {allocatedBytes}; bytes/call: {(double)allocatedBytes / Iterations:N2}");
@@ -33,13 +43,10 @@ public class MetricTagAllocationTest
     [Test]
     public async Task MetricTagLookup_DoesNotAllocateAfterInitialization()
     {
-        UseAllTagKinds();
+        LookUpTags(WarmupIterations);
 
         var before = GC.GetAllocatedBytesForCurrentThread();
-        for (var i = 0; i < Iterations; i++)
-        {
-            UseAllTagKinds();
-        }
+        LookUpTags(Iterations);
         var allocatedBytes = GC.GetAllocatedBytesForCurrentThread() - before;
 
         await Assert.That(allocatedBytes).IsEqualTo(0);
@@ -51,21 +58,41 @@ public class MetricTagAllocationTest
         var datadogHandler = new DatadogTrackerCallbackHandler(DisabledLogger);
         var loggerHandler = new LoggerTrackerCallbackHandler(DisabledLogger);
 
-        for (var i = 0; i < 1_000; i++)
-        {
-            datadogHandler.OnException(CallbackException);
-            loggerHandler.OnException(CallbackException);
-        }
+        ReportCallbackExceptions(datadogHandler, loggerHandler, WarmupIterations);
 
         var before = GC.GetAllocatedBytesForCurrentThread();
-        for (var i = 0; i < Iterations; i++)
-        {
-            datadogHandler.OnException(CallbackException);
-            loggerHandler.OnException(CallbackException);
-        }
+        ReportCallbackExceptions(datadogHandler, loggerHandler, Iterations);
         var allocatedBytes = GC.GetAllocatedBytesForCurrentThread() - before;
 
         await Assert.That(allocatedBytes).IsEqualTo(0);
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining | MethodImplOptions.AggressiveOptimization)]
+    private static void LogGcEvents(int iterations)
+    {
+        for (var i = 0; i < iterations; i++)
+        {
+            LoggerTracing.GcEventStartEnd(Statistics, DisabledLogger);
+        }
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining | MethodImplOptions.AggressiveOptimization)]
+    private static void LookUpTags(int iterations)
+    {
+        for (var i = 0; i < iterations; i++)
+        {
+            UseAllTagKinds();
+        }
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining | MethodImplOptions.AggressiveOptimization)]
+    private static void ReportCallbackExceptions(DatadogTrackerCallbackHandler datadogHandler, LoggerTrackerCallbackHandler loggerHandler, int iterations)
+    {
+        for (var i = 0; i < iterations; i++)
+        {
+            datadogHandler.OnException(CallbackException);
+            loggerHandler.OnException(CallbackException);
+        }
     }
 
     private static void UseAllTagKinds()

--- a/tests/CleProfiler.DatadogTracing.UnitTest/MetricTagProjectionTest.cs
+++ b/tests/CleProfiler.DatadogTracing.UnitTest/MetricTagProjectionTest.cs
@@ -24,6 +24,17 @@ public class MetricTagProjectionTest
     }
 
     [Test]
+    public async Task ContentionEventStartEnd_ProjectsAggregatedCountAndAverageDuration()
+    {
+        var logger = new CapturingLogger();
+
+        LoggerTracing.ContentionEventStartEnd(new ContentionEventStatistics(1, 0, 30, 3), logger);
+
+        await Assert.That(logger.Messages[0]).Contains("startend_count: 3,");
+        await Assert.That(logger.Messages[1]).Contains("startend_duration_ns: 10,");
+    }
+
+    [Test]
     [Arguments(0u, "soh")]
     [Arguments(1u, "induced")]
     [Arguments(2u, "low_memory")]

--- a/tests/CleProfiler.DatadogTracing.UnitTest/MetricTagProjectionTest.cs
+++ b/tests/CleProfiler.DatadogTracing.UnitTest/MetricTagProjectionTest.cs
@@ -24,7 +24,7 @@ public class MetricTagProjectionTest
     }
 
     [Test]
-    public async Task ContentionEventStartEnd_ProjectsAggregatedCountMaxAndSum()
+    public async Task ContentionEventStartEnd_ProjectsAggregatedCountSumAndMax()
     {
         var logger = new CapturingLogger();
 
@@ -32,8 +32,8 @@ public class MetricTagProjectionTest
 
         await Assert.That(logger.Messages).Count().IsEqualTo(3);
         await Assert.That(logger.Messages[0]).Contains("startend_count: 3,");
-        await Assert.That(logger.Messages[1]).Contains("startend_duration_ns: 40,");
-        await Assert.That(logger.Messages[2]).Contains("startend_duration_ns_sum: 90,");
+        await Assert.That(logger.Messages[1]).Contains("startend_duration_ns_sum: 90,");
+        await Assert.That(logger.Messages[2]).Contains("startend_duration_ns_max: 40,");
     }
 
     [Test]

--- a/tests/CleProfiler.DatadogTracing.UnitTest/MetricTagProjectionTest.cs
+++ b/tests/CleProfiler.DatadogTracing.UnitTest/MetricTagProjectionTest.cs
@@ -30,6 +30,7 @@ public class MetricTagProjectionTest
 
         LoggerTracing.ContentionEventStartEnd(new ContentionEventStatistics(1, 0, 30, 3), logger);
 
+        await Assert.That(logger.Messages).Count().IsEqualTo(2);
         await Assert.That(logger.Messages[0]).Contains("startend_count: 3,");
         await Assert.That(logger.Messages[1]).Contains("startend_duration_ns: 30,");
     }

--- a/tests/CleProfiler.DatadogTracing.UnitTest/MetricTagProjectionTest.cs
+++ b/tests/CleProfiler.DatadogTracing.UnitTest/MetricTagProjectionTest.cs
@@ -16,7 +16,7 @@ public class MetricTagProjectionTest
 
         LoggerTracing.ContentionEventStartEnd(new ContentionEventStatistics(1, flag, 2.5), logger);
 
-        await Assert.That(logger.Messages).Count().IsEqualTo(2);
+        await Assert.That(logger.Messages).Count().IsEqualTo(3);
         foreach (var message in logger.Messages)
         {
             await Assert.That(message).Contains($"tags: contention_type:{flag}");
@@ -24,15 +24,16 @@ public class MetricTagProjectionTest
     }
 
     [Test]
-    public async Task ContentionEventStartEnd_ProjectsAggregatedCountAndLatestDuration()
+    public async Task ContentionEventStartEnd_ProjectsAggregatedCountMaxAndSum()
     {
         var logger = new CapturingLogger();
 
-        LoggerTracing.ContentionEventStartEnd(new ContentionEventStatistics(1, 0, 30, 3), logger);
+        LoggerTracing.ContentionEventStartEnd(new ContentionEventStatistics(1, 0, 3, 90, 40), logger);
 
-        await Assert.That(logger.Messages).Count().IsEqualTo(2);
+        await Assert.That(logger.Messages).Count().IsEqualTo(3);
         await Assert.That(logger.Messages[0]).Contains("startend_count: 3,");
-        await Assert.That(logger.Messages[1]).Contains("startend_duration_ns: 30,");
+        await Assert.That(logger.Messages[1]).Contains("startend_duration_ns: 40,");
+        await Assert.That(logger.Messages[2]).Contains("startend_duration_ns_sum: 90,");
     }
 
     [Test]

--- a/tests/CleProfiler.DatadogTracing.UnitTest/MetricTagProjectionTest.cs
+++ b/tests/CleProfiler.DatadogTracing.UnitTest/MetricTagProjectionTest.cs
@@ -24,14 +24,14 @@ public class MetricTagProjectionTest
     }
 
     [Test]
-    public async Task ContentionEventStartEnd_ProjectsAggregatedCountAndAverageDuration()
+    public async Task ContentionEventStartEnd_ProjectsAggregatedCountAndLatestDuration()
     {
         var logger = new CapturingLogger();
 
         LoggerTracing.ContentionEventStartEnd(new ContentionEventStatistics(1, 0, 30, 3), logger);
 
         await Assert.That(logger.Messages[0]).Contains("startend_count: 3,");
-        await Assert.That(logger.Messages[1]).Contains("startend_duration_ns: 10,");
+        await Assert.That(logger.Messages[1]).Contains("startend_duration_ns: 30,");
     }
 
     [Test]

--- a/tests/CleProfiler.DatadogTracing.UnitTest/TestHelpers.cs
+++ b/tests/CleProfiler.DatadogTracing.UnitTest/TestHelpers.cs
@@ -1,7 +1,4 @@
 using Microsoft.Extensions.Logging;
-using System.Net;
-using System.Net.Sockets;
-using System.Text;
 
 namespace CleProfiler.DatadogTracing.UnitTest;
 
@@ -36,33 +33,6 @@ public static class TestHelpers
         for (int i = 0; i < 5000; i++)
         {
             int[] x = new int[100];
-        }
-    }
-
-    public class UdpServer : IDisposable
-    {
-        private UdpClient _udp;
-
-        public Action<IPEndPoint, string>? OnRecieveMessage { get; set; }
-
-        public UdpServer(string host, int port)
-        {
-            var endpoint = new System.Net.IPEndPoint(IPAddress.Parse(host), port);
-            _udp = new UdpClient(endpoint);
-        }
-
-        public void Dispose()
-        {
-            _udp.Dispose();
-        }
-
-        public async ValueTask ListenAsync(CancellationToken ct)
-        {
-            while (!ct.IsCancellationRequested)
-            {
-                var result = await _udp.ReceiveAsync(ct);
-                OnRecieveMessage?.Invoke(result.RemoteEndPoint, Encoding.UTF8.GetString(result.Buffer));
-            }
         }
     }
 }

--- a/tests/ClrProfiler.UnitTest/EventListenerDataIntegrityTest.cs
+++ b/tests/ClrProfiler.UnitTest/EventListenerDataIntegrityTest.cs
@@ -676,6 +676,99 @@ public class EventListenerDataIntegrityTest
     }
 
     [Test]
+    public async Task ContentionEventListenerDoesNotMergeAggregatesAcrossStopRestart()
+    {
+        var actual = new List<ContentionEventStatistics>(2);
+        using var cts = new CancellationTokenSource(TestTimeout);
+        using var listener = new TestableContentionEventListener(value =>
+        {
+            actual.Add(value);
+            if (actual.Count == 2)
+            {
+                cts.Cancel();
+            }
+            return Task.CompletedTask;
+        });
+        var beforeStop = new DateTime(2020, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+        var afterRestart = new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+
+        // A burst arrives while nothing is reading, then the listener stops.
+        for (var i = 0; i < 100; i++)
+        {
+            listener.ProcessEvent("ContentionStop_V1", beforeStop, [(byte)0, 0U, 1D]);
+        }
+        listener.Stop();
+
+        // Much later the listener restarts and a single new event arrives.
+        listener.Restart();
+        listener.ProcessEvent("ContentionStop_V1", afterRestart, [(byte)0, 0U, 9D]);
+
+        listener.EnableReading();
+        await listener.OnReadResultAsync(cts.Token);
+
+        // Two separate values: what was pending at Stop must not be folded into the events that
+        // arrive after Restart, and must keep its own timestamp.
+        await Assert.That(actual).Count().IsEqualTo(2);
+        await Assert.That(actual[0].Count).IsEqualTo(100L);
+        await Assert.That(actual[0].DurationNsSum).IsEqualTo(100D);
+        await Assert.That(actual[0].DurationNsMax).IsEqualTo(1D);
+        await Assert.That(actual[0].Time).IsEqualTo(beforeStop.Ticks);
+        await Assert.That(actual[1].Count).IsEqualTo(1L);
+        await Assert.That(actual[1].DurationNsSum).IsEqualTo(9D);
+        await Assert.That(actual[1].DurationNsMax).IsEqualTo(9D);
+        await Assert.That(actual[1].Time).IsEqualTo(afterRestart.Ticks);
+    }
+
+    [Test]
+    public async Task ContentionEventListenerStopWithNothingPendingEmitsNothing()
+    {
+        var actual = new List<ContentionEventStatistics>(1);
+        using var cts = new CancellationTokenSource(TimeSpan.FromMilliseconds(300));
+        using var listener = new TestableContentionEventListener(value =>
+        {
+            actual.Add(value);
+            return Task.CompletedTask;
+        });
+
+        listener.Stop();
+        listener.Stop();
+        listener.Restart();
+
+        listener.EnableReading();
+        await listener.OnReadResultAsync(cts.Token);
+
+        await Assert.That(actual).IsEmpty();
+    }
+
+    [Test]
+    public async Task ContentionEventListenerStopDeliversPendingAggregateToALaterReader()
+    {
+        var actual = new List<ContentionEventStatistics>(2);
+        using var cts = new CancellationTokenSource(TestTimeout);
+        using var listener = new TestableContentionEventListener(value =>
+        {
+            actual.Add(value);
+            if (actual.Sum(x => x.Count) == 2L)
+            {
+                cts.Cancel();
+            }
+            return Task.CompletedTask;
+        });
+        var origin = new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+
+        listener.ProcessEvent("ContentionStop_V1", origin, [(byte)0, 0U, 4D]);
+        listener.ProcessEvent("ContentionStop_V1", origin.AddTicks(1), [(byte)1, 0U, 6D]);
+        listener.Stop();
+
+        listener.EnableReading();
+        await listener.OnReadResultAsync(cts.Token);
+
+        // Stopping must not discard what was already observed.
+        await Assert.That(actual.Sum(value => value.Count)).IsEqualTo(2L);
+        await Assert.That(actual.Sum(value => value.DurationNsSum)).IsEqualTo(10D);
+    }
+
+    [Test]
     public async Task ContentionEventStatisticsEqualityIncludesEveryAggregateField()
     {
         var baseline = new ContentionEventStatistics(1, 0, 3, 90D, 40D);

--- a/tests/ClrProfiler.UnitTest/EventListenerDataIntegrityTest.cs
+++ b/tests/ClrProfiler.UnitTest/EventListenerDataIntegrityTest.cs
@@ -488,8 +488,8 @@ public class EventListenerDataIntegrityTest
         var native = actual.Single(value => value.Flag == 1);
         await Assert.That(managed.Count).IsEqualTo(eventCount / 2);
         await Assert.That(native.Count).IsEqualTo(eventCount / 2);
-        await Assert.That(managed.DurationNs).IsEqualTo(Enumerable.Range(0, eventCount).Where(i => i % 2 == 0).Sum(i => i + 0.5));
-        await Assert.That(native.DurationNs).IsEqualTo(Enumerable.Range(0, eventCount).Where(i => i % 2 == 1).Sum(i => i + 0.5));
+        await Assert.That(managed.DurationNs).IsEqualTo(eventCount - 2 + 0.5);
+        await Assert.That(native.DurationNs).IsEqualTo(eventCount - 1 + 0.5);
     }
 
     [Test]
@@ -521,9 +521,34 @@ public class EventListenerDataIntegrityTest
 
         await Assert.That(actual.Sum(value => value.Count)).IsEqualTo(eventCount);
         await Assert.That(actual.Where(value => value.Flag == 0).Sum(value => value.Count)).IsEqualTo(eventCount / 2);
-        await Assert.That(actual.Where(value => value.Flag == 0).Sum(value => value.DurationNs)).IsEqualTo(eventCount / 2 * 2D);
+        await Assert.That(actual.Where(value => value.Flag == 0).All(value => value.DurationNs == 2D)).IsTrue();
         await Assert.That(actual.Where(value => value.Flag == 1).Sum(value => value.Count)).IsEqualTo(eventCount / 2);
-        await Assert.That(actual.Where(value => value.Flag == 1).Sum(value => value.DurationNs)).IsEqualTo(eventCount / 2 * 3D);
+        await Assert.That(actual.Where(value => value.Flag == 1).All(value => value.DurationNs == 3D)).IsTrue();
+    }
+
+    [Test]
+    public async Task ContentionEventListenerDoesNotLoseCountsWhileReaderDrains()
+    {
+        const int eventCount = 10_000;
+        using var cts = new CancellationTokenSource(TestTimeout);
+        var observedCount = 0L;
+        using var listener = new TestableContentionEventListener(value =>
+        {
+            if (Interlocked.Add(ref observedCount, value.Count) == eventCount)
+            {
+                cts.Cancel();
+            }
+            return Task.CompletedTask;
+        });
+        object?[] payload = [(byte)0, 0U, 2D];
+
+        listener.EnableReading();
+        var readerTask = listener.OnReadResultAsync(cts.Token).AsTask();
+        Parallel.For(0, eventCount, i =>
+            listener.ProcessEvent("ContentionStop_V1", DateTime.UnixEpoch.AddTicks(i), payload));
+        await readerTask;
+
+        await Assert.That(observedCount).IsEqualTo(eventCount);
     }
 
     [Test]

--- a/tests/ClrProfiler.UnitTest/EventListenerDataIntegrityTest.cs
+++ b/tests/ClrProfiler.UnitTest/EventListenerDataIntegrityTest.cs
@@ -488,8 +488,118 @@ public class EventListenerDataIntegrityTest
         var native = actual.Single(value => value.Flag == 1);
         await Assert.That(managed.Count).IsEqualTo(eventCount / 2);
         await Assert.That(native.Count).IsEqualTo(eventCount / 2);
-        await Assert.That(managed.DurationNs).IsEqualTo(eventCount - 2 + 0.5);
-        await Assert.That(native.DurationNs).IsEqualTo(eventCount - 1 + 0.5);
+        // Every duration in the burst survives in the sum, and the largest one survives in the max.
+        await Assert.That(managed.DurationNsSum).IsEqualTo(ExpectedDurationSum(eventCount, 0));
+        await Assert.That(native.DurationNsSum).IsEqualTo(ExpectedDurationSum(eventCount, 1));
+        await Assert.That(managed.DurationNsMax).IsEqualTo(eventCount - 2 + 0.5);
+        await Assert.That(native.DurationNsMax).IsEqualTo(eventCount - 1 + 0.5);
+
+        static double ExpectedDurationSum(int eventCount, int flag)
+        {
+            var sum = 0D;
+            for (var i = flag; i < eventCount; i += 2)
+            {
+                sum += i + 0.5;
+            }
+            return sum;
+        }
+    }
+
+    [Test]
+    public async Task ContentionEventListenerAggregatesEveryDurationIntoSumAndMax()
+    {
+        double[] durations = [4.5, 100.25, 0.5, 12D, 100.25];
+        var actual = new List<ContentionEventStatistics>(1);
+        using var cts = new CancellationTokenSource(TestTimeout);
+        using var listener = new TestableContentionEventListener(value =>
+        {
+            actual.Add(value);
+            cts.Cancel();
+            return Task.CompletedTask;
+        });
+
+        var origin = new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+        for (var i = 0; i < durations.Length; i++)
+        {
+            listener.ProcessEvent("ContentionStop_V1", origin.AddTicks(i), [(byte)0, 0U, durations[i]]);
+        }
+
+        listener.EnableReading();
+        await listener.OnReadResultAsync(cts.Token);
+
+        var result = await Assert.That(actual).HasSingleItem();
+        await Assert.That(result.Count).IsEqualTo(5L);
+        await Assert.That(result.DurationNsSum).IsEqualTo(217.5D);
+        await Assert.That(result.DurationNsMax).IsEqualTo(100.25D);
+        await Assert.That(result.DurationNsMean).IsEqualTo(43.5D);
+        await Assert.That(result.Time).IsEqualTo(origin.AddTicks(durations.Length - 1).Ticks);
+    }
+
+    [Test]
+    public async Task ContentionEventListenerResetsDurationAggregatesBetweenFlushes()
+    {
+        var actual = new List<ContentionEventStatistics>(2);
+        using var firstFlush = new CancellationTokenSource(TestTimeout);
+        using var secondFlush = new CancellationTokenSource(TestTimeout);
+        var flushed = 0;
+        using var listener = new TestableContentionEventListener(value =>
+        {
+            actual.Add(value);
+            if (++flushed == 1)
+            {
+                firstFlush.Cancel();
+            }
+            else
+            {
+                secondFlush.Cancel();
+            }
+            return Task.CompletedTask;
+        });
+        var origin = new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+        listener.EnableReading();
+
+        listener.ProcessEvent("ContentionStop_V1", origin, [(byte)0, 0U, 90D]);
+        listener.ProcessEvent("ContentionStop_V1", origin.AddTicks(1), [(byte)0, 0U, 10D]);
+        await listener.OnReadResultAsync(firstFlush.Token);
+
+        listener.ProcessEvent("ContentionStop_V1", origin.AddTicks(2), [(byte)0, 0U, 3D]);
+        await listener.OnReadResultAsync(secondFlush.Token);
+
+        await Assert.That(actual).Count().IsEqualTo(2);
+        await Assert.That(actual[0].Count).IsEqualTo(2L);
+        await Assert.That(actual[0].DurationNsSum).IsEqualTo(100D);
+        await Assert.That(actual[0].DurationNsMax).IsEqualTo(90D);
+        // The second flush must not carry any part of the first one's durations.
+        await Assert.That(actual[1].Count).IsEqualTo(1L);
+        await Assert.That(actual[1].DurationNsSum).IsEqualTo(3D);
+        await Assert.That(actual[1].DurationNsMax).IsEqualTo(3D);
+    }
+
+    [Test]
+    public async Task ContentionEventListenerTreatsNonFiniteDurationAsZeroWithoutCorruptingTheSum()
+    {
+        var actual = new List<ContentionEventStatistics>(1);
+        using var cts = new CancellationTokenSource(TestTimeout);
+        using var listener = new TestableContentionEventListener(value =>
+        {
+            actual.Add(value);
+            cts.Cancel();
+            return Task.CompletedTask;
+        });
+        var origin = new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+
+        listener.ProcessEvent("ContentionStop_V1", origin, [(byte)0, 0U, double.NaN]);
+        listener.ProcessEvent("ContentionStop_V1", origin.AddTicks(1), [(byte)0, 0U, double.PositiveInfinity]);
+        listener.ProcessEvent("ContentionStop_V1", origin.AddTicks(2), [(byte)0, 0U, -5D]);
+        listener.ProcessEvent("ContentionStop_V1", origin.AddTicks(3), [(byte)0, 0U, 7D]);
+
+        listener.EnableReading();
+        await listener.OnReadResultAsync(cts.Token);
+
+        var result = await Assert.That(actual).HasSingleItem();
+        await Assert.That(result.Count).IsEqualTo(4L);
+        await Assert.That(result.DurationNsSum).IsEqualTo(7D);
+        await Assert.That(result.DurationNsMax).IsEqualTo(7D);
     }
 
     [Test]
@@ -521,26 +631,36 @@ public class EventListenerDataIntegrityTest
 
         await Assert.That(actual.Sum(value => value.Count)).IsEqualTo(eventCount);
         await Assert.That(actual.Where(value => value.Flag == 0).Sum(value => value.Count)).IsEqualTo(eventCount / 2);
-        await Assert.That(actual.Where(value => value.Flag == 0).All(value => value.DurationNs == 2D)).IsTrue();
+        await Assert.That(actual.Where(value => value.Flag == 0).Sum(value => value.DurationNsSum)).IsEqualTo(eventCount / 2 * 2D);
+        await Assert.That(actual.Where(value => value.Flag == 0).All(value => value.DurationNsMax == 2D)).IsTrue();
         await Assert.That(actual.Where(value => value.Flag == 1).Sum(value => value.Count)).IsEqualTo(eventCount / 2);
-        await Assert.That(actual.Where(value => value.Flag == 1).All(value => value.DurationNs == 3D)).IsTrue();
+        await Assert.That(actual.Where(value => value.Flag == 1).Sum(value => value.DurationNsSum)).IsEqualTo(eventCount / 2 * 3D);
+        await Assert.That(actual.Where(value => value.Flag == 1).All(value => value.DurationNsMax == 3D)).IsTrue();
     }
 
     [Test]
-    public async Task ContentionEventListenerDoesNotLoseCountsWhileReaderDrains()
+    public async Task ContentionEventListenerDoesNotLoseCountsOrDurationsWhileReaderDrains()
     {
         const int eventCount = 10_000;
+        const double durationNs = 2D;
         using var cts = new CancellationTokenSource(TestTimeout);
+        // Only the single reader loop invokes the callback, and the reader task is awaited
+        // before these are read, so plain accumulation is safe here.
         var observedCount = 0L;
+        var observedDurationSum = 0D;
+        var observedDurationMax = 0D;
         using var listener = new TestableContentionEventListener(value =>
         {
-            if (Interlocked.Add(ref observedCount, value.Count) == eventCount)
+            observedCount += value.Count;
+            observedDurationSum += value.DurationNsSum;
+            observedDurationMax = Math.Max(observedDurationMax, value.DurationNsMax);
+            if (observedCount == eventCount)
             {
                 cts.Cancel();
             }
             return Task.CompletedTask;
         });
-        object?[] payload = [(byte)0, 0U, 2D];
+        object?[] payload = [(byte)0, 0U, durationNs];
 
         listener.EnableReading();
         var readerTask = listener.OnReadResultAsync(cts.Token).AsTask();
@@ -549,17 +669,43 @@ public class EventListenerDataIntegrityTest
         await readerTask;
 
         await Assert.That(observedCount).IsEqualTo(eventCount);
+        // Each flush may be skewed by one event against its own count, but no duration may be
+        // dropped: the total across every flush has to match the total that was produced.
+        await Assert.That(observedDurationSum).IsEqualTo(eventCount * durationNs);
+        await Assert.That(observedDurationMax).IsEqualTo(durationNs);
     }
 
     [Test]
-    public async Task ContentionEventStatisticsEqualityIncludesAggregateCount()
+    public async Task ContentionEventStatisticsEqualityIncludesEveryAggregateField()
     {
-        var first = new ContentionEventStatistics(1, 0, 10, 1);
-        var second = new ContentionEventStatistics(1, 0, 10, 2);
+        var baseline = new ContentionEventStatistics(1, 0, 3, 90D, 40D);
 
-        await Assert.That(first.Equals(second)).IsFalse();
-        await Assert.That(first == second).IsFalse();
-        await Assert.That(first != second).IsTrue();
+        await Assert.That(baseline.Equals(new ContentionEventStatistics(1, 0, 3, 90D, 40D))).IsTrue();
+        await Assert.That(baseline == new ContentionEventStatistics(1, 0, 3, 90D, 40D)).IsTrue();
+        await Assert.That(baseline != new ContentionEventStatistics(2, 0, 3, 90D, 40D)).IsTrue();
+        await Assert.That(baseline != new ContentionEventStatistics(1, 1, 3, 90D, 40D)).IsTrue();
+        await Assert.That(baseline != new ContentionEventStatistics(1, 0, 4, 90D, 40D)).IsTrue();
+        await Assert.That(baseline != new ContentionEventStatistics(1, 0, 3, 91D, 40D)).IsTrue();
+        await Assert.That(baseline != new ContentionEventStatistics(1, 0, 3, 90D, 41D)).IsTrue();
+    }
+
+    [Test]
+    public async Task ContentionEventStatisticsSingleEventConstructorIsItsOwnSumAndMax()
+    {
+        var single = new ContentionEventStatistics(1, 0, 12.5D);
+
+        await Assert.That(single.Count).IsEqualTo(1L);
+        await Assert.That(single.DurationNsSum).IsEqualTo(12.5D);
+        await Assert.That(single.DurationNsMax).IsEqualTo(12.5D);
+        await Assert.That(single.DurationNsMean).IsEqualTo(12.5D);
+    }
+
+    [Test]
+    public async Task ContentionEventStatisticsMeanIsZeroWhenNothingWasAggregated()
+    {
+        var empty = new ContentionEventStatistics(1, 0, 0, 0D, 0D);
+
+        await Assert.That(empty.DurationNsMean).IsEqualTo(0D);
     }
 
     [Test]
@@ -605,7 +751,8 @@ public class EventListenerDataIntegrityTest
 
         var result = await Assert.That(actual).HasSingleItem();
         await Assert.That(result.Flag).IsEqualTo((byte)1);
-        await Assert.That(result.DurationNs).IsEqualTo(123.5D);
+        await Assert.That(result.DurationNsSum).IsEqualTo(123.5D);
+        await Assert.That(result.DurationNsMax).IsEqualTo(123.5D);
     }
 
     [Test]

--- a/tests/ClrProfiler.UnitTest/EventListenerDataIntegrityTest.cs
+++ b/tests/ClrProfiler.UnitTest/EventListenerDataIntegrityTest.cs
@@ -457,38 +457,84 @@ public class EventListenerDataIntegrityTest
     }
 
     [Test]
-    public async Task ContentionEventListenerPreservesEveryEventAtChannelCapacity()
+    public async Task ContentionEventListenerAtomicallyAggregatesBurstWithoutLoss()
     {
-        var actual = new List<ContentionEventStatistics>(ChannelCapacity);
+        const int eventCount = ChannelCapacity * 4;
+        var actual = new List<ContentionEventStatistics>(2);
         using var cts = new CancellationTokenSource(TestTimeout);
-        TestableContentionEventListener? listener = null;
-        listener = new TestableContentionEventListener(value =>
+        var observedCount = 0L;
+        using var listener = new TestableContentionEventListener(value =>
         {
             actual.Add(value);
-            if (actual.Count == ChannelCapacity)
+            observedCount += value.Count;
+            if (observedCount == eventCount)
             {
                 cts.Cancel();
             }
             return Task.CompletedTask;
         });
-        using (listener)
+
+        var origin = new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+        for (var i = 0; i < eventCount; i++)
         {
-            var origin = new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc);
-            for (var i = 0; i < ChannelCapacity; i++)
+            listener.ProcessEvent("ContentionStop_V1", origin.AddTicks(i), [(byte)(i % 2), 0U, i + 0.5]);
+        }
+
+        listener.EnableReading();
+        await listener.OnReadResultAsync(cts.Token);
+
+        await Assert.That(actual).Count().IsEqualTo(2);
+        var managed = actual.Single(value => value.Flag == 0);
+        var native = actual.Single(value => value.Flag == 1);
+        await Assert.That(managed.Count).IsEqualTo(eventCount / 2);
+        await Assert.That(native.Count).IsEqualTo(eventCount / 2);
+        await Assert.That(managed.DurationNs).IsEqualTo(Enumerable.Range(0, eventCount).Where(i => i % 2 == 0).Sum(i => i + 0.5));
+        await Assert.That(native.DurationNs).IsEqualTo(Enumerable.Range(0, eventCount).Where(i => i % 2 == 1).Sum(i => i + 0.5));
+    }
+
+    [Test]
+    public async Task ContentionEventListenerAtomicallyAggregatesConcurrentProducers()
+    {
+        const int eventCount = 10_000;
+        using var cts = new CancellationTokenSource(TestTimeout);
+        var actual = new List<ContentionEventStatistics>(2);
+        var observedCount = 0L;
+        using var listener = new TestableContentionEventListener(value =>
+        {
+            actual.Add(value);
+            observedCount += value.Count;
+            if (observedCount == eventCount)
             {
-                listener.ProcessEvent("ContentionStop_V1", origin.AddTicks(i), [(byte)(i % 2), 0U, i + 0.5]);
+                cts.Cancel();
             }
+            return Task.CompletedTask;
+        });
+        var origin = new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+        object?[] managedPayload = [(byte)0, 0U, 2D];
+        object?[] nativePayload = [(byte)1, 0U, 3D];
 
-            listener.EnableReading();
-            await listener.OnReadResultAsync(cts.Token);
-        }
+        Parallel.For(0, eventCount, i =>
+            listener.ProcessEvent("ContentionStop_V1", origin.AddTicks(i), i % 2 == 0 ? managedPayload : nativePayload));
 
-        await Assert.That(actual.Count).IsEqualTo(ChannelCapacity);
-        for (var i = 0; i < ChannelCapacity; i++)
-        {
-            await Assert.That(actual[i].Flag).IsEqualTo((byte)(i % 2));
-            await Assert.That(actual[i].DurationNs).IsEqualTo(i + 0.5);
-        }
+        listener.EnableReading();
+        await listener.OnReadResultAsync(cts.Token);
+
+        await Assert.That(actual.Sum(value => value.Count)).IsEqualTo(eventCount);
+        await Assert.That(actual.Where(value => value.Flag == 0).Sum(value => value.Count)).IsEqualTo(eventCount / 2);
+        await Assert.That(actual.Where(value => value.Flag == 0).Sum(value => value.DurationNs)).IsEqualTo(eventCount / 2 * 2D);
+        await Assert.That(actual.Where(value => value.Flag == 1).Sum(value => value.Count)).IsEqualTo(eventCount / 2);
+        await Assert.That(actual.Where(value => value.Flag == 1).Sum(value => value.DurationNs)).IsEqualTo(eventCount / 2 * 3D);
+    }
+
+    [Test]
+    public async Task ContentionEventStatisticsEqualityIncludesAggregateCount()
+    {
+        var first = new ContentionEventStatistics(1, 0, 10, 1);
+        var second = new ContentionEventStatistics(1, 0, 10, 2);
+
+        await Assert.That(first.Equals(second)).IsFalse();
+        await Assert.That(first == second).IsFalse();
+        await Assert.That(first != second).IsTrue();
     }
 
     [Test]


### PR DESCRIPTION
## Summary

Contention events were being aggregated per flag before dispatch (added earlier on this branch), but the aggregate carried only a single "latest" duration sample. Under a burst — exactly when contention data matters — almost every duration was overwritten and lost, and the surviving sample was not even guaranteed to belong to the same event as the timestamp beside it.

This replaces that single sample with a proper aggregate (`Count` / `DurationNsSum` / `DurationNsMax`), fixes the statsd metric types so the values survive interval aggregation, and makes `Stop()` a delivery boundary so pending work is never merged into post-restart events.

Measured with 100,000 concurrent events:

| | before | after |
|---|---|---|
| duration samples surviving | 146 of 100,000 (0.146%) | all — `sum` exact to the fractional nanosecond |
| `Time` / duration from different events | 125 of 248 dispatches (50.4%) | not possible by construction |

## Breaking changes

**`ContentionEventStatistics`** — `DurationNs` (a single arbitrary sample) is removed and replaced:

| member | meaning |
|---|---|
| `Count` | events represented |
| `DurationNsSum` | total ns across those events |
| `DurationNsMax` | longest single contention |
| `DurationNsMean` | `Sum / Count`, or 0 |
| `Time` | newest event observed for the flag |

The 3-argument constructor still exists for a single event (`Sum = Max = durationNs`), so code constructing one directly is source-compatible. Field layout changed, so this is binary breaking. `Equals`/`GetHashCode` now cover every field.

**Metrics** — `clr_diagnostics_event.contention.startend_duration_ns` is removed. Dashboards referencing it must be updated:

| metric | statsd type | value |
|---|---|---|
| `contention.startend_count` | counter | `Count` |
| `contention.startend_duration_ns_sum` | counter | `DurationNsSum` |
| `contention.startend_duration_ns_max` | **histogram** | `DurationNsMax` |

Read `startend_duration_ns_max.max` for the worst contention in an interval, and `_sum / _count` for the exact mean. The histogram's `.avg` and percentile series describe window maxima, not individual contentions.

## Intent

**Why sum and max, not the sample.** `Count` is a total and the old `DurationNs` was one sample, so `Count=50000, DurationNs=3.2` was uninterpretable. Count + sum + max is the shape OpenTelemetry histograms and Prometheus summaries use, and it is the most that can be maintained with lock-free per-event folding.

**Why the metric type mattered more than the name.** A statsd gauge keeps only the last value in a flush interval. The listener closes an aggregation window every time the reader drains — measured at ~338 windows/second — so a gauge discarded thousands of windows per flush and kept one. Counters and histograms compose across submissions; the maximum of window maxima is the true interval maximum. This is why the old metric never worked, independent of what it was named.

**Why picoseconds internally.** `Interlocked.Add` needs an integer, and a CAS loop over double bits would spin on the path that is by definition already contended. Picoseconds keep reported values exact while staying far from overflow. Non-finite and negative payloads contribute 0 rather than corrupting the sum.

**Why `Stop()` seals rather than discards.** Dropping pending aggregates would contradict the point of the change. `Stop()` now synchronously seals the accumulators into their own dispatch, keeping their own timestamp, so nothing is lost and nothing carries across a restart. Previously a pre-stop burst of 100 events was reported as `count=101` under a post-restart timestamp.

## Benchmarks

`E2EBenchmarks."Contended monitor"`, net10.0, 10 warmup / 30 iterations, AMD Ryzen 9 7950X3D.

| | tracking | Mean | Allocated |
|---|---|---|---|
| main | off | 113.0 us +/- 1.42 | 5.54 KB |
| main | **on** | 134.5 us +/- 1.39 | **14.46 KB** |
| this PR | off | 145.4 us +/- 4.20 | 5.90 KB |
| this PR | **on** | 118.6 us +/- 3.18 | **13.02 KB** |

**The timing column does not support any conclusion and should not be read as one.** The tracking-off rows run identical code with no profiler active, yet differ by 29% between the two runs; and this PR's tracking-on row is *faster* than its tracking-off row, which is impossible. Tight error bars show within-run stability, not run-to-run reproducibility on this machine. A clean timing claim needs a quieter host.

Allocation is the usable signal. Profiler-attributable allocation is 8.92 KB/op on main versus 7.12 KB/op here, consistent with the adapter formatting and sending statsd payloads once per aggregation window instead of once per event. Treat this as directional — allocation per operation also depends on how many contention events each run happened to generate.

The producer path is held to zero allocation deterministically by `ContentionEventListenerSupportedPayloadHotPathsDoNotAllocate`, which asserts exactly 0 bytes across 20,000 `ProcessEvent` calls.

## Also included

- Fixed an order-dependent failure in `CallbackExceptionLogging_WhenCriticalDisabled_DoesNotAllocate`. Root cause was on-stack replacement: a tier-0 measurement loop is swapped mid-flight and the transition allocates 24 bytes. Confirmed by reproducing it with an inert loop body, and by `DOTNET_TC_QuickJitForLoops=0` giving exactly 0. Measured loops now use `AggressiveOptimization` with warmup running the same method.
- Reworked the Datadog wire-level test harness. `DogStatsd.Configure` is process-global, so a second call made an earlier test hang forever on an unbounded wait loop with a fixed port. A session-shared fixture now owns the single configuration and binds port 0; waits are bounded and report which metrics are missing. Two full suites can now run concurrently, which was previously impossible.
- Corrected repo skill docs that claimed xUnit (the repo uses TUnit) and that no benchmark project existed.

## Verification

`ClrProfiler.UnitTest` 40/40, `CleProfiler.DatadogTracing.UnitTest` 44/44, `dotnet build -c Release` 0 warnings, `dotnet pack` 4 packages.