### PR TITLE
feat: redesign Contention aggregations

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ tracker.StartTracker();
 
 This approach allows you to integrate ClrProfiler with any metrics backend or implement custom logic for processing CLR events.
 
-Contention callbacks aggregate events by contention flag before dispatch, so one `ContentionEventStatistics` can represent many events. This keeps contention bursts intact when callback delivery is slower than event ingestion, without blocking the event producer.
+Contention callbacks place samples in a fixed-capacity MPSC queue and aggregate them by contention flag on the single reader. One `ContentionEventStatistics` can therefore represent many accepted events, while its `Count`, duration sum, maximum, and timestamp always come from the same delivery window.
 
 | Member | Meaning |
 | --- | --- |
@@ -148,21 +148,21 @@ Contention callbacks aggregate events by contention flag before dispatch, so one
 | `DurationNsMean` | `DurationNsSum / Count`, or 0 when nothing was aggregated. |
 | `Time` | Timestamp of the newest event observed for the flag. The duration fields summarize the whole window, so they are not tied to this timestamp. |
 
-Every event contributes to `Count` and `DurationNsSum`, so no duration is discarded no matter how large the burst. Durations accumulate as whole picoseconds internally, which keeps the per-event fold to a single lock-free add; non-finite or negative payload durations contribute 0 while still being counted.
+The producer never waits for the reader and does not use an unbounded spin loop. Queue reservation has a fixed retry limit; a sample is rejected when the queue is full or that limit is exhausted. `ContentionEventListener.DroppedEventCount` exposes the cumulative rejected count. Durations of accepted samples accumulate as whole picoseconds; non-finite or negative durations contribute 0 while still being counted.
 
-Aggregates are reset per dispatch. A single event's duration may be attributed to the dispatch immediately before the one carrying its count, so an individual value can be skewed by one event under concurrency. Totals across dispatches are exact.
+Aggregates are reset per dispatch. For accepted samples, every individual value and the totals across dispatches are exact.
 
-Stopping the profiler seals whatever is still aggregated and dispatches it as its own value, keeping the timestamp of the events it represents. Nothing observed before a stop is discarded, and nothing carries over into the events that arrive after a restart.
+Stopping the profiler advances the queue generation. Samples accepted before a stop are dispatched separately from samples accepted after a restart, even when the reader drains both generations later.
 
 A dispatch happens every time the reader drains, which is far more often than a metrics backend flushes. Contention metrics therefore only use statsd types that aggregate correctly over many submissions within one flush interval:
 
 | Metric | statsd type | Value | Why the type |
 | --- | --- | --- | --- |
-| `clr_diagnostics_event.contention.startend_count` | counter | `Count` | Counts add, so every dispatch is kept. |
-| `clr_diagnostics_event.contention.startend_duration_ns_sum` | counter | `DurationNsSum` | Sums add, so no duration is discarded. |
-| `clr_diagnostics_event.contention.startend_duration_ns_max` | histogram | `DurationNsMax` | The maximum of the submitted window maxima is the true maximum for the interval. |
+| `clr_diagnostics_event.contention.startend_count` | counter | `Count` | Counts add across every accepted dispatch. |
+| `clr_diagnostics_event.contention.startend_duration_ns_sum` | counter | `DurationNsSum` | Sums add across accepted samples. |
+| `clr_diagnostics_event.contention.startend_duration_ns_max` | histogram | `DurationNsMax` | The maximum of the accepted window maxima is the accepted maximum for the interval. |
 
-Read `startend_duration_ns_max.max` for the worst contention in an interval, and `startend_duration_ns_sum / startend_count` for the exact mean duration. The `.avg`, `.count`, and percentile series derived from the histogram describe window maxima rather than individual contentions, so do not read them as durations.
+Read `startend_duration_ns_max.max` for the worst accepted contention in an interval, and `startend_duration_ns_sum / startend_count` for the exact mean of accepted samples. The `.avg`, `.count`, and percentile series derived from the histogram describe window maxima rather than individual contentions, so do not read them as durations.
 
 A gauge is deliberately not used for any of these. A gauge keeps only the last value submitted within a flush interval, which would discard every aggregation window but one.
 

--- a/src/ClrProfiler/EventListeners/ContentionEventListener.cs
+++ b/src/ClrProfiler/EventListeners/ContentionEventListener.cs
@@ -15,17 +15,17 @@ public class ContentionEventListener : ProfileEventListenerBase, IChannelReader
 {
     private const int ContentionFlagCount = byte.MaxValue + 1;
     private const int MaxEnqueueAttempts = 8;
+    private const int MaxBatchSize = 1024;
     /// <summary>Picoseconds per nanosecond. Durations accumulate as whole picoseconds.</summary>
     private const double PicosecondsPerNanosecond = 1000D;
     /// <summary>
     /// Upper bound for a single event's contribution, roughly 2.5 hours. Real contention is
     /// orders of magnitude shorter; the cap only exists so a malformed payload cannot push the
-    /// accumulators toward overflow, and it takes 1024 capped events in one window to get there.
+    /// accumulator toward overflow when a full reader batch is folded into one window.
     /// </summary>
-    private const long MaxDurationPicoseconds = long.MaxValue / 1024;
+    private const long MaxDurationPicoseconds = long.MaxValue / MaxBatchSize;
 
     internal const int EventQueueCapacity = 4 * 1024;
-    private const int MaxBatchSize = 1024;
 
     private readonly BoundedMpscQueue<ContentionSample> _events = new(EventQueueCapacity);
     private readonly Channel<bool> _flushSignal;

--- a/src/ClrProfiler/EventListeners/ContentionEventListener.cs
+++ b/src/ClrProfiler/EventListeners/ContentionEventListener.cs
@@ -14,6 +14,7 @@ namespace ClrProfiler.EventListeners;
 public class ContentionEventListener : ProfileEventListenerBase, IChannelReader
 {
     private const int ContentionFlagCount = byte.MaxValue + 1;
+    private const int MaxEnqueueAttempts = 8;
     /// <summary>Picoseconds per nanosecond. Durations accumulate as whole picoseconds.</summary>
     private const double PicosecondsPerNanosecond = 1000D;
     /// <summary>
@@ -23,22 +24,27 @@ public class ContentionEventListener : ProfileEventListenerBase, IChannelReader
     /// </summary>
     private const long MaxDurationPicoseconds = long.MaxValue / 1024;
 
-    /// <summary>
-    /// How many <see cref="Stop"/>-sealed aggregates can wait for a reader. One entry per flag per
-    /// stop, so this only fills if the listener is stopped many times over with no reader draining,
-    /// in which case the oldest sealed values are the ones worth keeping.
-    /// </summary>
-    private const int SealedAggregateCapacity = 64;
+    internal const int EventQueueCapacity = 4 * 1024;
+    private const int MaxBatchSize = 1024;
 
+    private readonly BoundedMpscQueue<ContentionSample> _events = new(EventQueueCapacity);
     private readonly Channel<bool> _flushSignal;
-    private readonly Channel<ContentionEventStatistics> _sealedAggregates;
     private readonly Func<ContentionEventStatistics, Task> _onEventEmit;
     private readonly Action<Exception> _onEventError;
-    private readonly long[] _counts = new long[ContentionFlagCount];
-    private readonly long[] _durationSumPs = new long[ContentionFlagCount];
-    private readonly long[] _durationMaxPs = new long[ContentionFlagCount];
-    private readonly long[] _times = new long[ContentionFlagCount];
-    private readonly long[] _activeFlags = new long[ContentionFlagCount / 64];
+    private readonly long[] _readerCounts = new long[ContentionFlagCount];
+    private readonly long[] _readerDurationSumPs = new long[ContentionFlagCount];
+    private readonly long[] _readerDurationMaxPs = new long[ContentionFlagCount];
+    private readonly long[] _readerTimes = new long[ContentionFlagCount];
+    private readonly ulong[] _readerActiveFlags = new ulong[ContentionFlagCount / 64];
+    private long _generation;
+    private long _droppedEventCount;
+    private int _notificationPending;
+
+    /// <summary>
+    /// Gets the cumulative number of contention samples rejected because the fixed event queue
+    /// was full or a producer could not reserve a slot within the bounded retry limit.
+    /// </summary>
+    public long DroppedEventCount => Volatile.Read(ref _droppedEventCount);
 
     public ContentionEventListener(Func<ContentionEventStatistics, Task> onEventEmit, Action<Exception> onEventError) : base("Microsoft-Windows-DotNETRuntime", EventLevel.Informational, ClrRuntimeEventKeywords.Contention)
     {
@@ -51,12 +57,8 @@ public class ContentionEventListener : ProfileEventListenerBase, IChannelReader
             FullMode = BoundedChannelFullMode.DropWrite,
         };
         _flushSignal = Channel.CreateBounded<bool>(channelOption);
-        _sealedAggregates = Channel.CreateBounded<ContentionEventStatistics>(new BoundedChannelOptions(SealedAggregateCapacity)
-        {
-            SingleReader = true,
-            SingleWriter = false,
-            FullMode = BoundedChannelFullMode.DropWrite,
-        });
+        _flushSignal.Writer.TryWrite(true);
+        _flushSignal.Reader.TryRead(out _);
     }
 
     public override void EventCreatedHandler(EventWrittenEventArgs eventData)
@@ -85,26 +87,21 @@ public class ContentionEventListener : ProfileEventListenerBase, IChannelReader
     private void Aggregate(long time, byte flag, double durationNs)
     {
         var durationPs = ToPicoseconds(durationNs);
-
-        // Duration and timestamp are folded in before the count is incremented. The reader gates a
-        // flush on a non-zero count, so this order can only ever attribute a duration to the flush
-        // before its own count, never drop it. Incrementing first would let a duration strand until
-        // the next event for the same flag arrives.
-        Interlocked.Add(ref _durationSumPs[flag], durationPs);
-        InterlockedMax(ref _durationMaxPs[flag], durationPs);
-        InterlockedMax(ref _times[flag], time);
-        if (Interlocked.Increment(ref _counts[flag]) == 1)
+        if (!_events.TryEnqueue(new ContentionSample(time, Volatile.Read(ref _generation), durationPs, flag)))
         {
-            Interlocked.Or(ref _activeFlags[flag / 64], 1L << (flag % 64));
+            Interlocked.Increment(ref _droppedEventCount);
+            return;
+        }
+
+        if (Interlocked.Exchange(ref _notificationPending, 1) == 0)
+        {
             _flushSignal.Writer.TryWrite(true);
         }
     }
 
     /// <summary>
-    /// Converts a payload duration to whole picoseconds so the per-event fold stays a single
-    /// lock-free add. Accumulating the sum as a double would need a compare-exchange loop, which
-    /// spins on exactly the path that is by definition already contended. Picoseconds keep the
-    /// values the runtime reports exact while leaving the accumulator far from overflow.
+    /// Converts a payload duration to whole picoseconds before it enters the fixed event queue.
+    /// This lets the single reader accumulate durations with integer addition and no rounding drift.
     /// Non-finite and negative payloads contribute nothing rather than corrupting the sum.
     /// </summary>
     private static long ToPicoseconds(double durationNs)
@@ -124,90 +121,53 @@ public class ContentionEventListener : ProfileEventListenerBase, IChannelReader
     }
 
     /// <summary>
-    /// Raises <paramref name="location"/> to <paramref name="value"/> when it is larger. The loop
-    /// only retries when a concurrent writer also raised the value, so it is bounded by the number
-    /// of increases rather than by the number of writers.
-    /// </summary>
-    private static void InterlockedMax(ref long location, long value)
-    {
-        var current = Volatile.Read(ref location);
-        while (current < value)
-        {
-            var observed = Interlocked.CompareExchange(ref location, value, current);
-            if (observed == current)
-            {
-                return;
-            }
-            current = observed;
-        }
-    }
-
-    /// <summary>
-    /// Stops the listener and seals whatever is still aggregated so it is delivered as its own
-    /// value.
+    /// Stops the listener and advances the delivery generation.
     /// </summary>
     /// <remarks>
-    /// Without this, a burst that was observed but not yet dispatched stays in the accumulators and
-    /// is folded into the first events that arrive after <see cref="ProfileEventListenerBase.Restart"/>,
-    /// reporting old contention under a post-restart timestamp. Sealing happens synchronously here,
-    /// so by the time this returns the accumulators are empty and nothing can merge across the
-    /// boundary.
+    /// Queued samples retain their generation, so the reader emits pre-stop and post-restart samples
+    /// in separate aggregation windows even when both are drained later.
     /// </remarks>
     public override void Stop()
     {
         base.Stop();
+        Interlocked.Increment(ref _generation);
+    }
 
-        var sealedAny = false;
-        for (var wordIndex = 0; wordIndex < _activeFlags.Length; wordIndex++)
+    private void AggregateOnReader(in ContentionSample sample)
+    {
+        var flag = sample.Flag;
+        _readerCounts[flag]++;
+        _readerDurationSumPs[flag] += sample.DurationPs;
+        _readerDurationMaxPs[flag] = Math.Max(_readerDurationMaxPs[flag], sample.DurationPs);
+        _readerTimes[flag] = Math.Max(_readerTimes[flag], sample.Time);
+        _readerActiveFlags[flag / 64] |= 1UL << (flag % 64);
+    }
+
+    private async Task EmitReaderAggregatesAsync()
+    {
+        for (var wordIndex = 0; wordIndex < _readerActiveFlags.Length; wordIndex++)
         {
-            var activeFlags = (ulong)Interlocked.Exchange(ref _activeFlags[wordIndex], 0);
+            var activeFlags = _readerActiveFlags[wordIndex];
+            _readerActiveFlags[wordIndex] = 0;
             while (activeFlags != 0)
             {
                 var bitIndex = BitOperations.TrailingZeroCount(activeFlags);
                 var flag = (wordIndex * 64) + bitIndex;
                 activeFlags &= activeFlags - 1;
 
-                if (TryTakeAggregate(flag, out var value))
-                {
-                    sealedAny |= _sealedAggregates.Writer.TryWrite(value);
-                }
+                var value = new ContentionEventStatistics(
+                    _readerTimes[flag],
+                    (byte)flag,
+                    _readerCounts[flag],
+                    _readerDurationSumPs[flag] / PicosecondsPerNanosecond,
+                    _readerDurationMaxPs[flag] / PicosecondsPerNanosecond);
+                _readerCounts[flag] = 0;
+                _readerDurationSumPs[flag] = 0;
+                _readerDurationMaxPs[flag] = 0;
+                _readerTimes[flag] = 0;
+                await EmitAsync(value);
             }
         }
-
-        if (sealedAny)
-        {
-            _flushSignal.Writer.TryWrite(true);
-        }
-    }
-
-    /// <summary>
-    /// Takes everything aggregated for <paramref name="flag"/> and resets it for the next window.
-    /// Returns <see langword="false"/> when nothing was counted.
-    /// </summary>
-    private bool TryTakeAggregate(int flag, out ContentionEventStatistics value)
-    {
-        var count = Interlocked.Exchange(ref _counts[flag], 0);
-        if (count == 0)
-        {
-            // A producer sets the active bit before incrementing the count, so a bit can outlive
-            // the flush that already drained it. Leaving the duration accumulators alone here is
-            // what lets a duration folded in just before that flush be reported by the next one.
-            value = default;
-            return false;
-        }
-
-        var durationSumPs = Interlocked.Exchange(ref _durationSumPs[flag], 0);
-        var durationMaxPs = Interlocked.Exchange(ref _durationMaxPs[flag], 0);
-        // Read, not reset: this is the newest timestamp seen for the flag and must not regress to
-        // zero for a window whose event was counted after a reset.
-        var time = Volatile.Read(ref _times[flag]);
-        value = new ContentionEventStatistics(
-            time,
-            (byte)flag,
-            count,
-            durationSumPs / PicosecondsPerNanosecond,
-            durationMaxPs / PicosecondsPerNanosecond);
-        return true;
     }
 
     private async Task EmitAsync(ContentionEventStatistics value)
@@ -290,33 +250,128 @@ public class ContentionEventListener : ProfileEventListenerBase, IChannelReader
             {
                 while (_flushSignal.Reader.TryRead(out _))
                 {
-                    // Aggregates sealed by Stop come first so they keep their own timestamp and are
-                    // never reported after work that arrived on a later Restart.
-                    while (_sealedAggregates.Reader.TryRead(out var sealedValue))
+                    while (true)
                     {
-                        await EmitAsync(sealedValue);
-                    }
-
-                    for (var wordIndex = 0; wordIndex < _activeFlags.Length; wordIndex++)
-                    {
-                        var activeFlags = (ulong)Interlocked.Exchange(ref _activeFlags[wordIndex], 0);
-                        while (activeFlags != 0)
+                        var batchCount = 0;
+                        var generation = -1L;
+                        while (batchCount < MaxBatchSize && _events.TryDequeue(out var sample))
                         {
-                            var bitIndex = BitOperations.TrailingZeroCount(activeFlags);
-                            var flag = (wordIndex * 64) + bitIndex;
-                            activeFlags &= activeFlags - 1;
-
-                            if (TryTakeAggregate(flag, out var value))
+                            if (generation >= 0 && sample.Generation != generation)
                             {
-                                await EmitAsync(value);
+                                await EmitReaderAggregatesAsync();
+                                batchCount = 0;
                             }
+                            generation = sample.Generation;
+                            AggregateOnReader(in sample);
+                            batchCount++;
                         }
+
+                        if (batchCount != 0)
+                        {
+                            await EmitReaderAggregatesAsync();
+                        }
+
+                        if (batchCount == MaxBatchSize)
+                        {
+                            continue;
+                        }
+
+                        Volatile.Write(ref _notificationPending, 0);
+                        if (_events.HasReadyItem && Interlocked.Exchange(ref _notificationPending, 1) == 0)
+                        {
+                            continue;
+                        }
+                        break;
                     }
                 }
             }
         }
         catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
         {
+        }
+    }
+
+    private readonly record struct ContentionSample(long Time, long Generation, long DurationPs, byte Flag);
+
+    /// <summary>
+    /// Fixed-capacity MPSC queue. Producer reservation has a strict retry bound and never waits;
+    /// exhaustion is reported as a dropped event by the listener.
+    /// </summary>
+    private sealed class BoundedMpscQueue<T> where T : struct
+    {
+        private readonly Slot[] _slots;
+        private readonly int _mask;
+        private long _enqueuePosition;
+        private long _dequeuePosition;
+
+        public BoundedMpscQueue(int capacity)
+        {
+            if (capacity < 2 || !BitOperations.IsPow2(capacity))
+            {
+                throw new ArgumentOutOfRangeException(nameof(capacity), "Capacity must be a power of two.");
+            }
+
+            _slots = new Slot[capacity];
+            _mask = capacity - 1;
+            for (var i = 0; i < capacity; i++)
+            {
+                _slots[i].Sequence = i;
+            }
+        }
+
+        public bool HasReadyItem
+        {
+            get
+            {
+                var position = _dequeuePosition;
+                return Volatile.Read(ref _slots[(int)position & _mask].Sequence) == position + 1;
+            }
+        }
+
+        public bool TryEnqueue(T item)
+        {
+            for (var attempt = 0; attempt < MaxEnqueueAttempts; attempt++)
+            {
+                var position = Volatile.Read(ref _enqueuePosition);
+                ref var slot = ref _slots[(int)position & _mask];
+                var difference = Volatile.Read(ref slot.Sequence) - position;
+                if (difference < 0)
+                {
+                    return false;
+                }
+                if (difference == 0 &&
+                    Interlocked.CompareExchange(ref _enqueuePosition, position + 1, position) == position)
+                {
+                    slot.Item = item;
+                    Volatile.Write(ref slot.Sequence, position + 1);
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        public bool TryDequeue(out T item)
+        {
+            var position = _dequeuePosition;
+            ref var slot = ref _slots[(int)position & _mask];
+            if (Volatile.Read(ref slot.Sequence) != position + 1)
+            {
+                item = default;
+                return false;
+            }
+
+            item = slot.Item;
+            slot.Item = default;
+            Volatile.Write(ref slot.Sequence, position + _slots.Length);
+            _dequeuePosition = position + 1;
+            return true;
+        }
+
+        private struct Slot
+        {
+            public long Sequence;
+            public T Item;
         }
     }
 }

--- a/tests/ClrProfiler.UnitTest/EventListenerDataIntegrityTest.cs
+++ b/tests/ClrProfiler.UnitTest/EventListenerDataIntegrityTest.cs
@@ -603,19 +603,21 @@ public class EventListenerDataIntegrityTest
     }
 
     [Test]
-    public async Task ContentionEventListenerAtomicallyAggregatesConcurrentProducers()
+    public async Task ContentionEventListenerKeepsOrReportsEveryConcurrentProducerSample()
     {
         const int eventCount = 10_000;
         using var cts = new CancellationTokenSource(TestTimeout);
+        var completed = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
         var actual = new List<ContentionEventStatistics>(2);
         var observedCount = 0L;
+        var expectedCount = long.MaxValue;
         using var listener = new TestableContentionEventListener(value =>
         {
             actual.Add(value);
             observedCount += value.Count;
-            if (observedCount == eventCount)
+            if (observedCount == Volatile.Read(ref expectedCount))
             {
-                cts.Cancel();
+                completed.TrySetResult();
             }
             return Task.CompletedTask;
         });
@@ -626,37 +628,43 @@ public class EventListenerDataIntegrityTest
         Parallel.For(0, eventCount, i =>
             listener.ProcessEvent("ContentionStop_V1", origin.AddTicks(i), i % 2 == 0 ? managedPayload : nativePayload));
 
+        Volatile.Write(ref expectedCount, eventCount - listener.DroppedEventCount);
         listener.EnableReading();
-        await listener.OnReadResultAsync(cts.Token);
+        var readerTask = listener.OnReadResultAsync(cts.Token).AsTask();
+        await completed.Task.WaitAsync(TestTimeout, TestContext.Current!.Execution.CancellationToken);
+        await cts.CancelAsync();
+        await readerTask;
 
-        await Assert.That(actual.Sum(value => value.Count)).IsEqualTo(eventCount);
-        await Assert.That(actual.Where(value => value.Flag == 0).Sum(value => value.Count)).IsEqualTo(eventCount / 2);
-        await Assert.That(actual.Where(value => value.Flag == 0).Sum(value => value.DurationNsSum)).IsEqualTo(eventCount / 2 * 2D);
+        await Assert.That(actual.Sum(value => value.Count) + listener.DroppedEventCount).IsEqualTo(eventCount);
+        await Assert.That(actual.Where(value => value.Flag == 0).Sum(value => value.DurationNsSum))
+            .IsEqualTo(actual.Where(value => value.Flag == 0).Sum(value => value.Count) * 2D);
         await Assert.That(actual.Where(value => value.Flag == 0).All(value => value.DurationNsMax == 2D)).IsTrue();
-        await Assert.That(actual.Where(value => value.Flag == 1).Sum(value => value.Count)).IsEqualTo(eventCount / 2);
-        await Assert.That(actual.Where(value => value.Flag == 1).Sum(value => value.DurationNsSum)).IsEqualTo(eventCount / 2 * 3D);
+        await Assert.That(actual.Where(value => value.Flag == 1).Sum(value => value.DurationNsSum))
+            .IsEqualTo(actual.Where(value => value.Flag == 1).Sum(value => value.Count) * 3D);
         await Assert.That(actual.Where(value => value.Flag == 1).All(value => value.DurationNsMax == 3D)).IsTrue();
     }
 
     [Test]
-    public async Task ContentionEventListenerDoesNotLoseCountsOrDurationsWhileReaderDrains()
+    public async Task ContentionEventListenerKeepsWindowsConsistentWhileReaderDrains()
     {
         const int eventCount = 10_000;
         const double durationNs = 2D;
         using var cts = new CancellationTokenSource(TestTimeout);
+        var completed = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
         // Only the single reader loop invokes the callback, and the reader task is awaited
         // before these are read, so plain accumulation is safe here.
         var observedCount = 0L;
         var observedDurationSum = 0D;
         var observedDurationMax = 0D;
+        var expectedCount = long.MaxValue;
         using var listener = new TestableContentionEventListener(value =>
         {
             observedCount += value.Count;
             observedDurationSum += value.DurationNsSum;
             observedDurationMax = Math.Max(observedDurationMax, value.DurationNsMax);
-            if (observedCount == eventCount)
+            if (observedCount == Volatile.Read(ref expectedCount))
             {
-                cts.Cancel();
+                completed.TrySetResult();
             }
             return Task.CompletedTask;
         });
@@ -666,13 +674,85 @@ public class EventListenerDataIntegrityTest
         var readerTask = listener.OnReadResultAsync(cts.Token).AsTask();
         Parallel.For(0, eventCount, i =>
             listener.ProcessEvent("ContentionStop_V1", DateTime.UnixEpoch.AddTicks(i), payload));
+        Volatile.Write(ref expectedCount, eventCount - listener.DroppedEventCount);
+        if (Volatile.Read(ref observedCount) == expectedCount)
+        {
+            completed.TrySetResult();
+        }
+        await completed.Task.WaitAsync(TestTimeout, TestContext.Current!.Execution.CancellationToken);
+        await cts.CancelAsync();
         await readerTask;
 
-        await Assert.That(observedCount).IsEqualTo(eventCount);
-        // Each flush may be skewed by one event against its own count, but no duration may be
-        // dropped: the total across every flush has to match the total that was produced.
-        await Assert.That(observedDurationSum).IsEqualTo(eventCount * durationNs);
+        await Assert.That(observedCount + listener.DroppedEventCount).IsEqualTo(eventCount);
+        await Assert.That(observedDurationSum).IsEqualTo(observedCount * durationNs);
         await Assert.That(observedDurationMax).IsEqualTo(durationNs);
+    }
+
+    [Test]
+    public async Task ContentionEventListenerKeepsCountAndDurationInTheSameFlushWindow()
+    {
+        const int eventCount = 10_000;
+        const double durationNs = 2D;
+        using var cts = new CancellationTokenSource(TestTimeout);
+        var completed = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var observedCount = 0L;
+        var inconsistentWindow = false;
+        var expectedCount = long.MaxValue;
+        using var listener = new TestableContentionEventListener(value =>
+        {
+            observedCount += value.Count;
+            inconsistentWindow |= value.DurationNsSum != value.Count * durationNs;
+            if (observedCount == Volatile.Read(ref expectedCount))
+            {
+                completed.TrySetResult();
+            }
+            return Task.CompletedTask;
+        });
+        object?[] payload = [(byte)0, 0U, durationNs];
+
+        listener.EnableReading();
+        var readerTask = listener.OnReadResultAsync(cts.Token).AsTask();
+        Parallel.For(0, eventCount, i =>
+            listener.ProcessEvent("ContentionStop_V1", DateTime.UnixEpoch.AddTicks(i), payload));
+        Volatile.Write(ref expectedCount, eventCount - listener.DroppedEventCount);
+        if (Volatile.Read(ref observedCount) == expectedCount)
+        {
+            completed.TrySetResult();
+        }
+        await completed.Task.WaitAsync(TestTimeout, TestContext.Current!.Execution.CancellationToken);
+        await cts.CancelAsync();
+        await readerTask;
+
+        await Assert.That(observedCount + listener.DroppedEventCount).IsEqualTo(eventCount);
+        await Assert.That(inconsistentWindow).IsFalse();
+    }
+
+    [Test]
+    public async Task ContentionEventListenerReportsSamplesDroppedAtTheBoundedQueue()
+    {
+        var observedCount = 0L;
+        using var cts = new CancellationTokenSource(TestTimeout);
+        using var listener = new TestableContentionEventListener(value =>
+        {
+            observedCount += value.Count;
+            if (observedCount == ContentionEventListener.EventQueueCapacity)
+            {
+                cts.Cancel();
+            }
+            return Task.CompletedTask;
+        });
+        object?[] payload = [(byte)0, 0U, 1D];
+
+        for (var i = 0; i <= ContentionEventListener.EventQueueCapacity; i++)
+        {
+            listener.ProcessEvent("ContentionStop_V1", DateTime.UnixEpoch.AddTicks(i), payload);
+        }
+
+        listener.EnableReading();
+        await listener.OnReadResultAsync(cts.Token);
+
+        await Assert.That(observedCount).IsEqualTo(ContentionEventListener.EventQueueCapacity);
+        await Assert.That(listener.DroppedEventCount).IsEqualTo(1L);
     }
 
     [Test]
@@ -766,6 +846,37 @@ public class EventListenerDataIntegrityTest
         // Stopping must not discard what was already observed.
         await Assert.That(actual.Sum(value => value.Count)).IsEqualTo(2L);
         await Assert.That(actual.Sum(value => value.DurationNsSum)).IsEqualTo(10D);
+    }
+
+    [Test]
+    public async Task ContentionEventListenerStopPreservesEveryPendingFlag()
+    {
+        const int flagCount = byte.MaxValue + 1;
+        var actual = new List<ContentionEventStatistics>(flagCount);
+        using var cts = new CancellationTokenSource(TestTimeout);
+        using var listener = new TestableContentionEventListener(value =>
+        {
+            actual.Add(value);
+            if (actual.Count == flagCount)
+            {
+                cts.Cancel();
+            }
+            return Task.CompletedTask;
+        });
+        var origin = new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+
+        for (var flag = 0; flag < flagCount; flag++)
+        {
+            listener.ProcessEvent("ContentionStop_V1", origin.AddTicks(flag), [(byte)flag, 0U, flag + 0.5D]);
+        }
+        listener.Stop();
+
+        listener.EnableReading();
+        await listener.OnReadResultAsync(cts.Token);
+
+        await Assert.That(actual).Count().IsEqualTo(flagCount);
+        await Assert.That(actual.Sum(value => value.Count)).IsEqualTo(flagCount);
+        await Assert.That(actual.Select(value => value.Flag).Distinct()).Count().IsEqualTo(flagCount);
     }
 
     [Test]


### PR DESCRIPTION
## Summary

- Redesign contention aggregation around a fixed-capacity MPSC queue.
- Aggregate count, sum, max, and timestamp on the single reader.
- Add regression tests for window consistency, Stop/Restart boundaries, all 256 flags, and dropped samples.

## Intent

Keep contention event producers bounded, non-blocking, and allocation-free while ensuring every emitted aggregate represents one consistent event window.

## Behavior Changes

- Removes independent atomic aggregation that could split count and duration across flush windows.
- Uses a 4,096-sample queue with at most eight reservation attempts.
- Never waits or spins indefinitely on producer threads.
- Exposes rejected samples through `ContentionEventListener.DroppedEventCount`.
- Preserves pre-stop and post-restart samples as separate generations.
- Maintains 0 B allocation on the supported producer hot path.

## Verification

- Release multi-target build: passed with no warnings
- Tests: 87/87 passed
- NuGet packaging: passed

## Benchmark

BenchmarkDotNet ShortRun on .NET 9:

| Tracking | Mean | Allocated |
| --- | ---: | ---: |
| Disabled | 189.0 µs | 4.36 KB |
| Enabled | 186.7 µs | 8.07 KB |

The E2E benchmark does not synchronize reader draining, so these results are informational. No numeric performance improvement is claimed.