### PR TITLE
fix: ThreadPool behaviour is multithreaded bu SigleWriter = true.

### DIFF
--- a/src/ClrProfiler/EventListeners/ThreadPoolEventListener.cs
+++ b/src/ClrProfiler/EventListeners/ThreadPoolEventListener.cs
@@ -22,7 +22,9 @@ public class ThreadPoolEventListener : ProfileEventListenerBase, IChannelReader
         var channelOption = new BoundedChannelOptions(50)
         {
             SingleReader = true,
-            SingleWriter = true,
+            // EventListener callbacks run on the threads that emit the runtime events, so multiple
+            // application and ThreadPool threads can write concurrently.
+            SingleWriter = false,
             FullMode = BoundedChannelFullMode.DropOldest,
         };
         _channel = Channel.CreateBounded<ThreadPoolEventStatistics>(channelOption);

--- a/tests/ClrProfiler.UnitTest/EventListenerDataIntegrityTest.cs
+++ b/tests/ClrProfiler.UnitTest/EventListenerDataIntegrityTest.cs
@@ -1007,6 +1007,60 @@ public class EventListenerDataIntegrityTest
     }
 
     [Test]
+    public async Task ThreadPoolEventListenerPreservesCapacityBoundedEventsFromConcurrentWriters()
+    {
+        const int writerCount = 5;
+        const int eventsPerWriter = ChannelCapacity / writerCount;
+        var actual = new List<ThreadPoolEventStatistics>(ChannelCapacity);
+        using var cts = new CancellationTokenSource(TestTimeout);
+        using var start = new ManualResetEventSlim();
+        using var listener = new TestableThreadPoolEventListener(value =>
+        {
+            actual.Add(value);
+            if (actual.Count == ChannelCapacity)
+            {
+                cts.Cancel();
+            }
+            return Task.CompletedTask;
+        });
+        var writers = new Thread[writerCount];
+
+        for (var writerIndex = 0; writerIndex < writerCount; writerIndex++)
+        {
+            var capturedWriterIndex = writerIndex;
+            writers[writerIndex] = new Thread(() =>
+            {
+                start.Wait();
+                for (var eventIndex = 0; eventIndex < eventsPerWriter; eventIndex++)
+                {
+                    var value = (uint)((capturedWriterIndex * eventsPerWriter) + eventIndex + 1);
+                    listener.ProcessEvent("ThreadPoolWorkerThreadStop_V1", DateTime.UnixEpoch.AddTicks(value), [value]);
+                }
+            });
+            writers[writerIndex].Start();
+        }
+
+        start.Set();
+        foreach (var writer in writers)
+        {
+            if (!writer.Join(TestTimeout))
+            {
+                throw new TimeoutException("A concurrent ThreadPool event writer did not complete.");
+            }
+        }
+
+        listener.EnableReading();
+        await listener.OnReadResultAsync(cts.Token);
+
+        await Assert.That(actual).Count().IsEqualTo(ChannelCapacity);
+        var activeWorkerCounts = actual
+            .Select(value => value.ThreadPoolWorker.ActiveWrokerThreads)
+            .Order()
+            .ToArray();
+        await Assert.That(activeWorkerCounts).IsEquivalentTo(Enumerable.Range(1, ChannelCapacity).Select(value => (uint)value));
+    }
+
+    [Test]
     public async Task ThreadPoolEventListenerSupportedPayloadHotPathsDoNotAllocate()
     {
         using var listener = new TestableThreadPoolEventListener(_ => Task.CompletedTask);

--- a/tests/ClrProfiler.UnitTest/EventListenerDataIntegrityTest.cs
+++ b/tests/ClrProfiler.UnitTest/EventListenerDataIntegrityTest.cs
@@ -1009,8 +1009,9 @@ public class EventListenerDataIntegrityTest
     [Test]
     public async Task ThreadPoolEventListenerPreservesCapacityBoundedEventsFromConcurrentWriters()
     {
-        const int writerCount = 5;
-        const int eventsPerWriter = ChannelCapacity / writerCount;
+        var writerCount = 5;
+        await Assert.That(ChannelCapacity % writerCount).IsEqualTo(0);
+        var eventsPerWriter = ChannelCapacity / writerCount;
         var actual = new List<ThreadPoolEventStatistics>(ChannelCapacity);
         using var cts = new CancellationTokenSource(TestTimeout);
         using var start = new ManualResetEventSlim();


### PR DESCRIPTION
## Summary

- Configure the ThreadPool event channel for concurrent writers.
- Add a regression test using five concurrent producers.
- Verify all capacity-bounded events are delivered without duplication or loss.

## Intent

`EventListener` callbacks can run on multiple event-emitting threads. Declaring `SingleWriter = false` aligns the channel configuration with the actual producer model and avoids relying on runtime implementation details.

## Verification

- Tests: 88/88 passed
- Multi-target Release build: passed with no warnings
- NuGet packaging: passed
- Producer hot path: 0 B allocated

## Benchmark

BenchmarkDotNet ShortRun on .NET 9:

| Tracking | Mean | Allocated |
| --- | ---: | ---: |
| Disabled | 126.1 µs | 234 B |
| Enabled | 123.2 µs | 295 B |

The benchmark is informational; no numeric performance improvement is claimed.