### PR TITLE
feat: Observe silent drop event count

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,8 @@ tracker.StartTracker();
 
 This approach allows you to integrate ClrProfiler with any metrics backend or implement custom logic for processing CLR events.
 
+Bounded delivery queues keep producers non-blocking and retain the newest values when a reader falls behind. `GCEventListener`, `ThreadPoolEventListener`, `GCInfoTimerListener`, `ProcessInfoTimerListener`, and `ThreadInfoTimerListener` expose a cumulative `DroppedEventCount` for values evicted from their delivery channels. The counter is thread-safe and is not reset by stop or restart.
+
 Contention callbacks place samples in a fixed-capacity MPSC queue and aggregate them by contention flag on the single reader. One `ContentionEventStatistics` can therefore represent many accepted events, while its `Count`, duration sum, maximum, and timestamp always come from the same delivery window.
 
 | Member | Meaning |

--- a/src/ClrProfiler/EventListeners/GCEventListener.cs
+++ b/src/ClrProfiler/EventListeners/GCEventListener.cs
@@ -19,12 +19,18 @@ public class GCEventListener : ProfileEventListenerBase, IChannelReader
     private readonly Func<GCEventStatistics, Task> _onEventEmit;
     private readonly Action<Exception> _onEventError;
     private readonly GCStartStateSlot[] _gcStartStates = new GCStartStateSlot[GCStartStateCapacity];
+    private long _droppedEventCount;
 
     // suspend
     private long _suspendOwner;
     private long _suspendTimeGCStart;
     private uint _suspendReason;
     private uint _suspendCount;
+
+    /// <summary>
+    /// Gets the cumulative number of events evicted from the bounded delivery channel.
+    /// </summary>
+    public long DroppedEventCount => Volatile.Read(ref _droppedEventCount);
 
     public GCEventListener(Func<GCEventStatistics, Task> onEventEmit, Action<Exception> onEventError) : base("Microsoft-Windows-DotNETRuntime", EventLevel.Informational, ClrRuntimeEventKeywords.GC)
     {
@@ -36,8 +42,10 @@ public class GCEventListener : ProfileEventListenerBase, IChannelReader
             SingleWriter = false,
             FullMode = BoundedChannelFullMode.DropOldest,
         };
-        _channel = Channel.CreateBounded<GCEventStatistics>(channelOption);
+        _channel = Channel.CreateBounded<GCEventStatistics>(channelOption, OnItemDropped);
     }
+
+    private void OnItemDropped(GCEventStatistics _) => Interlocked.Increment(ref _droppedEventCount);
 
     // GC Flow
     // Foreground (Blocking) GC flow (all Gen 0/1 GCs and full blocking GCs)

--- a/src/ClrProfiler/EventListeners/ThreadPoolEventListener.cs
+++ b/src/ClrProfiler/EventListeners/ThreadPoolEventListener.cs
@@ -14,6 +14,12 @@ public class ThreadPoolEventListener : ProfileEventListenerBase, IChannelReader
     private readonly Channel<ThreadPoolEventStatistics> _channel;
     private readonly Func<ThreadPoolEventStatistics, Task> _onEventEmit;
     private readonly Action<Exception> _onEventError;
+    private long _droppedEventCount;
+
+    /// <summary>
+    /// Gets the cumulative number of events evicted from the bounded delivery channel.
+    /// </summary>
+    public long DroppedEventCount => Volatile.Read(ref _droppedEventCount);
 
     public ThreadPoolEventListener(Func<ThreadPoolEventStatistics, Task> onEventEmit, Action<Exception> onEventError) : base("Microsoft-Windows-DotNETRuntime", EventLevel.Informational, ClrRuntimeEventKeywords.Threading)
     {
@@ -27,8 +33,10 @@ public class ThreadPoolEventListener : ProfileEventListenerBase, IChannelReader
             SingleWriter = false,
             FullMode = BoundedChannelFullMode.DropOldest,
         };
-        _channel = Channel.CreateBounded<ThreadPoolEventStatistics>(channelOption);
+        _channel = Channel.CreateBounded<ThreadPoolEventStatistics>(channelOption, OnItemDropped);
     }
+
+    private void OnItemDropped(ThreadPoolEventStatistics _) => Interlocked.Increment(ref _droppedEventCount);
 
     public override void EventCreatedHandler(EventWrittenEventArgs eventData)
     {

--- a/src/ClrProfiler/TimerListeners/GCInfoTimerListener.cs
+++ b/src/ClrProfiler/TimerListeners/GCInfoTimerListener.cs
@@ -18,9 +18,15 @@ public class GCInfoTimerListener : TimerListenerBase, IDisposable, IChannelReade
     private readonly Action<Exception> _onEventError;
     private readonly TimeSpan _dueTime;
     private readonly TimeSpan _intervalPeriod;
+    private long _droppedEventCount;
 
     private readonly Func<int, ulong>? _getGenerationSizeDelegate;
     private readonly Func<int>? _getLastGCPercentTimeInGC;
+
+    /// <summary>
+    /// Gets the cumulative number of samples evicted from the bounded delivery channel.
+    /// </summary>
+    public long DroppedEventCount => Volatile.Read(ref _droppedEventCount);
 
     /// <summary>
     /// Constructor
@@ -40,7 +46,7 @@ public class GCInfoTimerListener : TimerListenerBase, IDisposable, IChannelReade
             SingleWriter = true,
             SingleReader = true,
             FullMode = BoundedChannelFullMode.DropOldest,
-        });
+        }, OnItemDropped);
 
         var methodGetGenerationSize = typeof(GC).GetMethod("GetGenerationSize", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Static | System.Reflection.BindingFlags.FlattenHierarchy);
         _getGenerationSizeDelegate = (Func<int, ulong>?)methodGetGenerationSize?.CreateDelegate(typeof(Func<int, ulong>));
@@ -48,6 +54,8 @@ public class GCInfoTimerListener : TimerListenerBase, IDisposable, IChannelReade
         var methodGetLastGCPercentTimeInGC = typeof(GC).GetMethod("GetLastGCPercentTimeInGC", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Static | System.Reflection.BindingFlags.FlattenHierarchy);
         _getLastGCPercentTimeInGC = (Func<int>?)methodGetLastGCPercentTimeInGC?.CreateDelegate(typeof(Func<int>));
     }
+
+    private void OnItemDropped(GCInfoStatistics _) => Interlocked.Increment(ref _droppedEventCount);
 
     protected override void OnEventWritten()
     {

--- a/src/ClrProfiler/TimerListeners/ProcessInfoTimerListener.cs
+++ b/src/ClrProfiler/TimerListeners/ProcessInfoTimerListener.cs
@@ -24,6 +24,12 @@ public class ProcessInfoTimerListener : TimerListenerBase, IDisposable, IChannel
     private readonly Action<Exception> _onEventError;
     private readonly TimeSpan _dueTime;
     private readonly TimeSpan _intervalPeriod;
+    private long _droppedEventCount;
+
+    /// <summary>
+    /// Gets the cumulative number of samples evicted from the bounded delivery channel.
+    /// </summary>
+    public long DroppedEventCount => Volatile.Read(ref _droppedEventCount);
 
     /// <summary>
     /// Constructor
@@ -45,8 +51,10 @@ public class ProcessInfoTimerListener : TimerListenerBase, IDisposable, IChannel
             SingleWriter = true,
             SingleReader = true,
             FullMode = BoundedChannelFullMode.DropOldest,
-        });
+        }, OnItemDropped);
     }
+
+    private void OnItemDropped(ProcessInfoStatistics _) => Interlocked.Increment(ref _droppedEventCount);
 
     protected override void OnEventWritten()
     {

--- a/src/ClrProfiler/TimerListeners/ThreadInfoTimerListener.cs
+++ b/src/ClrProfiler/TimerListeners/ThreadInfoTimerListener.cs
@@ -17,6 +17,12 @@ public class ThreadInfoTimerListener : TimerListenerBase, IDisposable, IChannelR
     private readonly Action<Exception> _onEventError;
     private readonly TimeSpan _dueTime;
     private readonly TimeSpan _intervalPeriod;
+    private long _droppedEventCount;
+
+    /// <summary>
+    /// Gets the cumulative number of samples evicted from the bounded delivery channel.
+    /// </summary>
+    public long DroppedEventCount => Volatile.Read(ref _droppedEventCount);
 
     /// <summary>
     /// Constructor
@@ -36,8 +42,10 @@ public class ThreadInfoTimerListener : TimerListenerBase, IDisposable, IChannelR
             SingleWriter = true,
             SingleReader = true,
             FullMode = BoundedChannelFullMode.DropOldest,
-        });
+        }, OnItemDropped);
     }
+
+    private void OnItemDropped(ThreadInfoStatistics _) => Interlocked.Increment(ref _droppedEventCount);
 
     protected override void OnEventWritten()
     {

--- a/tests/ClrProfiler.UnitTest/EventListenerDataIntegrityTest.cs
+++ b/tests/ClrProfiler.UnitTest/EventListenerDataIntegrityTest.cs
@@ -64,6 +64,41 @@ public class EventListenerDataIntegrityTest
     }
 
     [Test]
+    public async Task GCEventListenerReportsEventsDroppedBeyondChannelCapacity()
+    {
+        var actual = new List<GCEventStatistics>(ChannelCapacity);
+        using var cts = new CancellationTokenSource(TestTimeout);
+        using var listener = new TestableGCEventListener(value =>
+        {
+            actual.Add(value);
+            if (actual.Count == ChannelCapacity)
+            {
+                cts.Cancel();
+            }
+            return Task.CompletedTask;
+        });
+        var origin = new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+
+        for (var i = 0; i < ChannelCapacity; i++)
+        {
+            listener.ProcessEvent("GCSuspendEEBegin_V1", origin.AddTicks(i * 2L), [1U, (uint)i]);
+            listener.ProcessEvent("GCRestartEEEnd_V1", origin.AddTicks((i * 2L) + 1), []);
+        }
+        await Assert.That(listener.DroppedEventCount).IsEqualTo(0L);
+
+        listener.ProcessEvent("GCSuspendEEBegin_V1", origin.AddTicks(ChannelCapacity * 2L), [1U, (uint)ChannelCapacity]);
+        listener.ProcessEvent("GCRestartEEEnd_V1", origin.AddTicks((ChannelCapacity * 2L) + 1), []);
+
+        await Assert.That(listener.DroppedEventCount).IsEqualTo(1L);
+        listener.EnableReading();
+        await listener.OnReadResultAsync(cts.Token);
+
+        await Assert.That(actual).Count().IsEqualTo(ChannelCapacity);
+        await Assert.That(actual[0].GCSuspendStatistics.Count).IsEqualTo(1U);
+        await Assert.That(actual[^1].GCSuspendStatistics.Count).IsEqualTo((uint)ChannelCapacity);
+    }
+
+    [Test]
     public async Task GCEventListenerCorrelatesOverlappingCollectionsByIndex()
     {
         var actual = new List<GCEventStatistics>(2);
@@ -1059,6 +1094,38 @@ public class EventListenerDataIntegrityTest
             .Order()
             .ToArray();
         await Assert.That(activeWorkerCounts).IsEquivalentTo(Enumerable.Range(1, ChannelCapacity).Select(value => (uint)value));
+    }
+
+    [Test]
+    public async Task ThreadPoolEventListenerReportsEventsDroppedBeyondChannelCapacity()
+    {
+        var actual = new List<ThreadPoolEventStatistics>(ChannelCapacity);
+        using var cts = new CancellationTokenSource(TestTimeout);
+        using var listener = new TestableThreadPoolEventListener(value =>
+        {
+            actual.Add(value);
+            if (actual.Count == ChannelCapacity)
+            {
+                cts.Cancel();
+            }
+            return Task.CompletedTask;
+        });
+
+        for (var i = 0; i < ChannelCapacity; i++)
+        {
+            listener.ProcessEvent("ThreadPoolWorkerThreadStop_V1", DateTime.UnixEpoch.AddTicks(i), [(uint)i]);
+        }
+        await Assert.That(listener.DroppedEventCount).IsEqualTo(0L);
+
+        listener.ProcessEvent("ThreadPoolWorkerThreadStop_V1", DateTime.UnixEpoch.AddTicks(ChannelCapacity), [(uint)ChannelCapacity]);
+
+        await Assert.That(listener.DroppedEventCount).IsEqualTo(1L);
+        listener.EnableReading();
+        await listener.OnReadResultAsync(cts.Token);
+
+        await Assert.That(actual).Count().IsEqualTo(ChannelCapacity);
+        await Assert.That(actual[0].ThreadPoolWorker.ActiveWrokerThreads).IsEqualTo(1U);
+        await Assert.That(actual[^1].ThreadPoolWorker.ActiveWrokerThreads).IsEqualTo((uint)ChannelCapacity);
     }
 
     [Test]

--- a/tests/ClrProfiler.UnitTest/TimerListenerDataIntegrityTest.cs
+++ b/tests/ClrProfiler.UnitTest/TimerListenerDataIntegrityTest.cs
@@ -49,6 +49,35 @@ public class TimerListenerDataIntegrityTest
     }
 
     [Test]
+    public async Task GCInfoTimerListenerReportsSamplesDroppedBeyondChannelCapacity()
+    {
+        var actual = new List<GCInfoStatistics>(ChannelCapacity);
+        using var cts = new CancellationTokenSource(TestTimeout);
+        using var listener = new TestableGCInfoTimerListener(value =>
+        {
+            actual.Add(value);
+            if (actual.Count == ChannelCapacity)
+            {
+                cts.Cancel();
+            }
+            return Task.CompletedTask;
+        });
+
+        for (var i = 0; i < ChannelCapacity; i++)
+        {
+            listener.EventCreatedHandler();
+        }
+        await Assert.That(listener.DroppedEventCount).IsEqualTo(0L);
+
+        listener.EventCreatedHandler();
+
+        await Assert.That(listener.DroppedEventCount).IsEqualTo(1L);
+        listener.EnableReading();
+        await listener.OnReadResultAsync(cts.Token);
+        await Assert.That(actual).Count().IsEqualTo(ChannelCapacity);
+    }
+
+    [Test]
     public async Task ProcessInfoTimerListenerPreservesEverySampleAtChannelCapacity()
     {
         var actual = new List<ProcessInfoStatistics>(ChannelCapacity);
@@ -82,6 +111,35 @@ public class TimerListenerDataIntegrityTest
             await Assert.That(value.WorkingSet > 0).IsTrue();
             await Assert.That(value.PrivateBytes > 0).IsTrue();
         }
+    }
+
+    [Test]
+    public async Task ProcessInfoTimerListenerReportsSamplesDroppedBeyondChannelCapacity()
+    {
+        var actual = new List<ProcessInfoStatistics>(ChannelCapacity);
+        using var cts = new CancellationTokenSource(TestTimeout);
+        using var listener = new TestableProcessInfoTimerListener(value =>
+        {
+            actual.Add(value);
+            if (actual.Count == ChannelCapacity)
+            {
+                cts.Cancel();
+            }
+            return Task.CompletedTask;
+        });
+
+        for (var i = 0; i < ChannelCapacity; i++)
+        {
+            listener.EventCreatedHandler();
+        }
+        await Assert.That(listener.DroppedEventCount).IsEqualTo(0L);
+
+        listener.EventCreatedHandler();
+
+        await Assert.That(listener.DroppedEventCount).IsEqualTo(1L);
+        listener.EnableReading();
+        await listener.OnReadResultAsync(cts.Token);
+        await Assert.That(actual).Count().IsEqualTo(ChannelCapacity);
     }
 
     [Test]
@@ -121,6 +179,35 @@ public class TimerListenerDataIntegrityTest
             await Assert.That(value.UsingWorkerThreads).IsEqualTo(value.MaxWorkerThreads - value.AvailableWorkerThreads);
             await Assert.That(value.UsingCompletionPortThreads).IsEqualTo(value.MaxCompletionPortThreads - value.AvailableCompletionPortThreads);
         }
+    }
+
+    [Test]
+    public async Task ThreadInfoTimerListenerReportsSamplesDroppedBeyondChannelCapacity()
+    {
+        var actual = new List<ThreadInfoStatistics>(ChannelCapacity);
+        using var cts = new CancellationTokenSource(TestTimeout);
+        using var listener = new TestableThreadInfoTimerListener(value =>
+        {
+            actual.Add(value);
+            if (actual.Count == ChannelCapacity)
+            {
+                cts.Cancel();
+            }
+            return Task.CompletedTask;
+        });
+
+        for (var i = 0; i < ChannelCapacity; i++)
+        {
+            listener.EventCreatedHandler();
+        }
+        await Assert.That(listener.DroppedEventCount).IsEqualTo(0L);
+
+        listener.EventCreatedHandler();
+
+        await Assert.That(listener.DroppedEventCount).IsEqualTo(1L);
+        listener.EnableReading();
+        await listener.OnReadResultAsync(cts.Token);
+        await Assert.That(actual).Count().IsEqualTo(ChannelCapacity);
     }
 
     private sealed class TestableGCInfoTimerListener(Func<GCInfoStatistics, Task> onEventEmit)


### PR DESCRIPTION
## Summary

- Expose cumulative `DroppedEventCount` on GC, ThreadPool, and timer listeners.
- Count items evicted by bounded `DropOldest` channels.
- Add boundary tests covering channel capacity and overflow behavior.
- Document the delivery and counter semantics.

## Motivation

Bounded channels intentionally drop old values when readers fall behind, but these drops were previously silent. The new counters make event loss observable without blocking producers or adding per-event allocations.

## Benchmark / Verification

- Hot-path allocation regression test remains at **0 B**
- **93 tests passed**
- Release build passed for all target frameworks with **0 warnings**
- NuGet packaging passed