### PR TITLE
refactor: Prepare BoundedChannelDispatcher and use it in each listener, change to ValueTask

### DIFF
--- a/src/ClrProfiler/EventListeners/BoundedChannelDispatcher.cs
+++ b/src/ClrProfiler/EventListeners/BoundedChannelDispatcher.cs
@@ -1,0 +1,65 @@
+using System.Threading.Channels;
+
+namespace ClrProfiler.EventListeners;
+
+/// <summary>
+/// Owns bounded, non-blocking delivery for listeners that retain the newest values when full.
+/// </summary>
+internal sealed class BoundedChannelDispatcher<T> where T : struct
+{
+    private readonly Channel<T> _channel;
+    private readonly Func<T, Task>? _onEventEmit;
+    private readonly Action<Exception> _onEventError;
+    private long _droppedEventCount;
+
+    public long DroppedEventCount => Volatile.Read(ref _droppedEventCount);
+
+    public BoundedChannelDispatcher(
+        int capacity,
+        bool singleWriter,
+        Func<T, Task>? onEventEmit,
+        Action<Exception> onEventError)
+    {
+        _onEventEmit = onEventEmit;
+        _onEventError = onEventError;
+        _channel = Channel.CreateBounded<T>(new BoundedChannelOptions(capacity)
+        {
+            SingleReader = true,
+            SingleWriter = singleWriter,
+            FullMode = BoundedChannelFullMode.DropOldest,
+        }, OnItemDropped);
+    }
+
+    public void TryWrite(T value) => _channel.Writer.TryWrite(value);
+
+    public async ValueTask ReadAllAsync(CancellationToken cancellationToken)
+    {
+        try
+        {
+            while (await _channel.Reader.WaitToReadAsync(cancellationToken))
+            {
+                while (_channel.Reader.TryRead(out var value))
+                {
+                    if (_onEventEmit is null)
+                    {
+                        continue;
+                    }
+
+                    try
+                    {
+                        await _onEventEmit.Invoke(value);
+                    }
+                    catch (Exception ex)
+                    {
+                        _onEventError.Invoke(ex);
+                    }
+                }
+            }
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+        }
+    }
+
+    private void OnItemDropped(T _) => Interlocked.Increment(ref _droppedEventCount);
+}

--- a/src/ClrProfiler/EventListeners/GCEventListener.cs
+++ b/src/ClrProfiler/EventListeners/GCEventListener.cs
@@ -1,6 +1,5 @@
 using ClrProfiler.Statistics;
 using System.Diagnostics.Tracing;
-using System.Threading.Channels;
 
 namespace ClrProfiler.EventListeners;
 
@@ -15,11 +14,9 @@ public class GCEventListener : ProfileEventListenerBase, IChannelReader
     // allowing indices separated by the table capacity to remain active together.
     private const int GCStartStateCapacity = 64;
 
-    private readonly Channel<GCEventStatistics> _channel;
-    private readonly Func<GCEventStatistics, Task> _onEventEmit;
+    private readonly BoundedChannelDispatcher<GCEventStatistics> _dispatcher;
     private readonly Action<Exception> _onEventError;
     private readonly GCStartStateSlot[] _gcStartStates = new GCStartStateSlot[GCStartStateCapacity];
-    private long _droppedEventCount;
 
     // suspend
     private long _suspendOwner;
@@ -30,22 +27,13 @@ public class GCEventListener : ProfileEventListenerBase, IChannelReader
     /// <summary>
     /// Gets the cumulative number of events evicted from the bounded delivery channel.
     /// </summary>
-    public long DroppedEventCount => Volatile.Read(ref _droppedEventCount);
+    public long DroppedEventCount => _dispatcher.DroppedEventCount;
 
     public GCEventListener(Func<GCEventStatistics, Task> onEventEmit, Action<Exception> onEventError) : base("Microsoft-Windows-DotNETRuntime", EventLevel.Informational, ClrRuntimeEventKeywords.GC)
     {
-        _onEventEmit = onEventEmit;
         _onEventError = onEventError;
-        var channelOption = new BoundedChannelOptions(50)
-        {
-            SingleReader = true,
-            SingleWriter = false,
-            FullMode = BoundedChannelFullMode.DropOldest,
-        };
-        _channel = Channel.CreateBounded<GCEventStatistics>(channelOption, OnItemDropped);
+        _dispatcher = new BoundedChannelDispatcher<GCEventStatistics>(50, singleWriter: false, onEventEmit, onEventError);
     }
-
-    private void OnItemDropped(GCEventStatistics _) => Interlocked.Increment(ref _droppedEventCount);
 
     // GC Flow
     // Foreground (Blocking) GC flow (all Gen 0/1 GCs and full blocking GCs)
@@ -127,7 +115,7 @@ public class GCEventListener : ProfileEventListenerBase, IChannelReader
                 var stat = new GCStartEndStatistics(gcIndex, startState.Type, generation, startState.Reason, duration, startState.StartTime, timeGCEnd);
 
                 // write to channel
-                _channel.Writer.TryWrite(new GCEventStatistics(GCEventType.GCStartEnd, stat, new()));
+                _dispatcher.TryWrite(new GCEventStatistics(GCEventType.GCStartEnd, stat, new()));
             }
             else if (eventName.StartsWith("GCSuspendEEBegin", StringComparison.OrdinalIgnoreCase))
             {
@@ -151,7 +139,7 @@ public class GCEventListener : ProfileEventListenerBase, IChannelReader
                 var stat = new GCSuspendStatistics(duration, suspendReason, suspendCount);
 
                 // write to channel
-                _channel.Writer.TryWrite(new GCEventStatistics(GCEventType.GCSuspend, new(), stat));
+                _dispatcher.TryWrite(new GCEventStatistics(GCEventType.GCSuspend, new(), stat));
             }
         }
         catch (Exception ex)
@@ -336,31 +324,5 @@ public class GCEventListener : ProfileEventListenerBase, IChannelReader
         Dropped,
     }
 
-    public async ValueTask OnReadResultAsync(CancellationToken cancellationToken = default)
-    {
-        try
-        {
-            // Keep the reader alive across Stop/Restart. Cancellation owns its lifetime.
-            while (await _channel.Reader.WaitToReadAsync(cancellationToken))
-            {
-                while (_channel.Reader.TryRead(out var value))
-                {
-                    if (_onEventEmit != null)
-                    {
-                        try
-                        {
-                            await _onEventEmit.Invoke(value);
-                        }
-                        catch (Exception ex)
-                        {
-                            _onEventError.Invoke(ex);
-                        }
-                    }
-                }
-            }
-        }
-        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
-        {
-        }
-    }
+    public ValueTask OnReadResultAsync(CancellationToken cancellationToken = default) => _dispatcher.ReadAllAsync(cancellationToken);
 }

--- a/src/ClrProfiler/EventListeners/ThreadPoolEventListener.cs
+++ b/src/ClrProfiler/EventListeners/ThreadPoolEventListener.cs
@@ -1,7 +1,6 @@
 using ClrProfiler.Statistics;
 using System.Diagnostics.Tracing;
 using System.Globalization;
-using System.Threading.Channels;
 
 namespace ClrProfiler.EventListeners;
 
@@ -11,32 +10,21 @@ namespace ClrProfiler.EventListeners;
 /// <remarks>payload: https://docs.microsoft.com/en-us/dotnet/framework/performance/thread-pool-etw-events </remarks>
 public class ThreadPoolEventListener : ProfileEventListenerBase, IChannelReader
 {
-    private readonly Channel<ThreadPoolEventStatistics> _channel;
-    private readonly Func<ThreadPoolEventStatistics, Task> _onEventEmit;
+    private readonly BoundedChannelDispatcher<ThreadPoolEventStatistics> _dispatcher;
     private readonly Action<Exception> _onEventError;
-    private long _droppedEventCount;
 
     /// <summary>
     /// Gets the cumulative number of events evicted from the bounded delivery channel.
     /// </summary>
-    public long DroppedEventCount => Volatile.Read(ref _droppedEventCount);
+    public long DroppedEventCount => _dispatcher.DroppedEventCount;
 
     public ThreadPoolEventListener(Func<ThreadPoolEventStatistics, Task> onEventEmit, Action<Exception> onEventError) : base("Microsoft-Windows-DotNETRuntime", EventLevel.Informational, ClrRuntimeEventKeywords.Threading)
     {
-        _onEventEmit = onEventEmit;
         _onEventError = onEventError;
-        var channelOption = new BoundedChannelOptions(50)
-        {
-            SingleReader = true,
-            // EventListener callbacks run on the threads that emit the runtime events, so multiple
-            // application and ThreadPool threads can write concurrently.
-            SingleWriter = false,
-            FullMode = BoundedChannelFullMode.DropOldest,
-        };
-        _channel = Channel.CreateBounded<ThreadPoolEventStatistics>(channelOption, OnItemDropped);
+        // EventListener callbacks run on the threads that emit the runtime events, so multiple
+        // application and ThreadPool threads can write concurrently.
+        _dispatcher = new BoundedChannelDispatcher<ThreadPoolEventStatistics>(50, singleWriter: false, onEventEmit, onEventError);
     }
-
-    private void OnItemDropped(ThreadPoolEventStatistics _) => Interlocked.Increment(ref _droppedEventCount);
 
     public override void EventCreatedHandler(EventWrittenEventArgs eventData)
     {
@@ -63,7 +51,7 @@ public class ThreadPoolEventListener : ProfileEventListenerBase, IChannelReader
                 var stat = new ThreadPoolEventStatistics(ThreadPoolStatisticType.ThreadPoolAdjustment, new(), new ThreadPoolAdjustmentStatistics(time, averageThroughput, newWorkerThreadCount, reason));
 
                 // write to channel
-                _channel.Writer.TryWrite(stat);
+                _dispatcher.TryWrite(stat);
             }
             else if (eventName?.StartsWith("ThreadPoolWorkerThreadStop", StringComparison.OrdinalIgnoreCase) ?? false)
             {
@@ -73,7 +61,7 @@ public class ThreadPoolEventListener : ProfileEventListenerBase, IChannelReader
                 var stat = new ThreadPoolEventStatistics(ThreadPoolStatisticType.ThreadPoolWorkerStartStop, new ThreadPoolWorkerStatistics(time, activeWorkerThreadCount), new());
 
                 // write to channel
-                _channel.Writer.TryWrite(stat);
+                _dispatcher.TryWrite(stat);
             }
         }
         catch (Exception ex)
@@ -141,31 +129,5 @@ public class ThreadPoolEventListener : ProfileEventListenerBase, IChannelReader
         };
     }
 
-    public async ValueTask OnReadResultAsync(CancellationToken cancellationToken = default)
-    {
-        try
-        {
-            // Keep the reader alive across Stop/Restart. Cancellation owns its lifetime.
-            while (await _channel.Reader.WaitToReadAsync(cancellationToken))
-            {
-                while (_channel.Reader.TryRead(out var value))
-                {
-                    if (_onEventEmit != null)
-                    {
-                        try
-                        {
-                            await _onEventEmit.Invoke(value);
-                        }
-                        catch (Exception ex)
-                        {
-                            _onEventError.Invoke(ex);
-                        }
-                    }
-                }
-            }
-        }
-        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
-        {
-        }
-    }
+    public ValueTask OnReadResultAsync(CancellationToken cancellationToken = default) => _dispatcher.ReadAllAsync(cancellationToken);
 }

--- a/src/ClrProfiler/TimerListeners/GCInfoTimerListener.cs
+++ b/src/ClrProfiler/TimerListeners/GCInfoTimerListener.cs
@@ -13,12 +13,10 @@ public class GCInfoTimerListener : TimerListenerBase, IDisposable, IChannelReade
 
     public ChannelReader<GCInfoStatistics>? Reader { get; set; }
 
-    private readonly Channel<GCInfoStatistics> _channel;
-    private readonly Func<GCInfoStatistics, Task> _onEventEmit;
+    private readonly BoundedChannelDispatcher<GCInfoStatistics> _dispatcher;
     private readonly Action<Exception> _onEventError;
     private readonly TimeSpan _dueTime;
     private readonly TimeSpan _intervalPeriod;
-    private long _droppedEventCount;
 
     private readonly Func<int, ulong>? _getGenerationSizeDelegate;
     private readonly Func<int>? _getLastGCPercentTimeInGC;
@@ -26,7 +24,7 @@ public class GCInfoTimerListener : TimerListenerBase, IDisposable, IChannelReade
     /// <summary>
     /// Gets the cumulative number of samples evicted from the bounded delivery channel.
     /// </summary>
-    public long DroppedEventCount => Volatile.Read(ref _droppedEventCount);
+    public long DroppedEventCount => _dispatcher.DroppedEventCount;
 
     /// <summary>
     /// Constructor
@@ -37,16 +35,10 @@ public class GCInfoTimerListener : TimerListenerBase, IDisposable, IChannelReade
     /// <param name="intervalPeriod">The time inteval between the invocation of timer.</param>
     public GCInfoTimerListener(Func<GCInfoStatistics, Task> onEventEmit, Action<Exception> onEventError, TimeSpan dueTime, TimeSpan intervalPeriod)
     {
-        _onEventEmit = onEventEmit;
         _onEventError = onEventError;
         _dueTime = dueTime;
         _intervalPeriod = intervalPeriod;
-        _channel = Channel.CreateBounded<GCInfoStatistics>(new BoundedChannelOptions(50)
-        {
-            SingleWriter = true,
-            SingleReader = true,
-            FullMode = BoundedChannelFullMode.DropOldest,
-        }, OnItemDropped);
+        _dispatcher = new BoundedChannelDispatcher<GCInfoStatistics>(50, singleWriter: true, onEventEmit, onEventError);
 
         var methodGetGenerationSize = typeof(GC).GetMethod("GetGenerationSize", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Static | System.Reflection.BindingFlags.FlattenHierarchy);
         _getGenerationSizeDelegate = (Func<int, ulong>?)methodGetGenerationSize?.CreateDelegate(typeof(Func<int, ulong>));
@@ -54,8 +46,6 @@ public class GCInfoTimerListener : TimerListenerBase, IDisposable, IChannelReade
         var methodGetLastGCPercentTimeInGC = typeof(GC).GetMethod("GetLastGCPercentTimeInGC", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Static | System.Reflection.BindingFlags.FlattenHierarchy);
         _getLastGCPercentTimeInGC = (Func<int>?)methodGetLastGCPercentTimeInGC?.CreateDelegate(typeof(Func<int>));
     }
-
-    private void OnItemDropped(GCInfoStatistics _) => Interlocked.Increment(ref _droppedEventCount);
 
     protected override void OnEventWritten()
     {
@@ -94,33 +84,7 @@ public class GCInfoTimerListener : TimerListenerBase, IDisposable, IChannelReade
         timer?.Dispose();
     }
 
-    public async ValueTask OnReadResultAsync(CancellationToken cancellationToken)
-    {
-        try
-        {
-            // Keep the reader alive across Stop/Restart. Cancellation owns its lifetime.
-            while (await _channel.Reader.WaitToReadAsync(cancellationToken))
-            {
-                while (_channel.Reader.TryRead(out var value))
-                {
-                    if (_onEventEmit != null)
-                    {
-                        try
-                        {
-                            await _onEventEmit.Invoke(value);
-                        }
-                        catch (Exception ex)
-                        {
-                            _onEventError.Invoke(ex);
-                        }
-                    }
-                }
-            }
-        }
-        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
-        {
-        }
-    }
+    public ValueTask OnReadResultAsync(CancellationToken cancellationToken) => _dispatcher.ReadAllAsync(cancellationToken);
 
     public override void EventCreatedHandler()
     {
@@ -144,7 +108,7 @@ public class GCInfoTimerListener : TimerListenerBase, IDisposable, IChannelReade
             var timeInGc = _getLastGCPercentTimeInGC?.Invoke() ?? 0;
             var stat = new GCInfoStatistics(date, gcmode, compactionMode, latencyMode, heapSize, totalAllocationBytes, gen0Count, gen1Count, gen2Count, timeInGc, gen0Size, gen1Size, gen2Size, lohSize);
 
-            _channel.Writer.TryWrite(stat);
+            _dispatcher.TryWrite(stat);
         }
         catch (Exception ex)
         {

--- a/src/ClrProfiler/TimerListeners/ProcessInfoTimerListener.cs
+++ b/src/ClrProfiler/TimerListeners/ProcessInfoTimerListener.cs
@@ -19,17 +19,15 @@ public class ProcessInfoTimerListener : TimerListenerBase, IDisposable, IChannel
 
     public ChannelReader<ProcessInfoStatistics>? Reader { get; set; }
 
-    private readonly Channel<ProcessInfoStatistics> _channel;
-    private readonly Func<ProcessInfoStatistics, Task> _onEventEmit;
+    private readonly BoundedChannelDispatcher<ProcessInfoStatistics> _dispatcher;
     private readonly Action<Exception> _onEventError;
     private readonly TimeSpan _dueTime;
     private readonly TimeSpan _intervalPeriod;
-    private long _droppedEventCount;
 
     /// <summary>
     /// Gets the cumulative number of samples evicted from the bounded delivery channel.
     /// </summary>
-    public long DroppedEventCount => Volatile.Read(ref _droppedEventCount);
+    public long DroppedEventCount => _dispatcher.DroppedEventCount;
 
     /// <summary>
     /// Constructor
@@ -40,21 +38,13 @@ public class ProcessInfoTimerListener : TimerListenerBase, IDisposable, IChannel
     /// <param name="intervalPeriod">The time inteval between the invocation of timer.</param>
     public ProcessInfoTimerListener(Func<ProcessInfoStatistics, Task> onEventEmit, Action<Exception> onEventError, TimeSpan dueTime, TimeSpan intervalPeriod)
     {
-        _onEventEmit = onEventEmit;
         _onEventError = onEventError;
         _dueTime = dueTime;
         _intervalPeriod = intervalPeriod;
         _oldCPUTime = _process.TotalProcessorTime;
         _lastMonitorTime = DateTime.UtcNow;
-        _channel = Channel.CreateBounded<ProcessInfoStatistics>(new BoundedChannelOptions(50)
-        {
-            SingleWriter = true,
-            SingleReader = true,
-            FullMode = BoundedChannelFullMode.DropOldest,
-        }, OnItemDropped);
+        _dispatcher = new BoundedChannelDispatcher<ProcessInfoStatistics>(50, singleWriter: true, onEventEmit, onEventError);
     }
-
-    private void OnItemDropped(ProcessInfoStatistics _) => Interlocked.Increment(ref _droppedEventCount);
 
     protected override void OnEventWritten()
     {
@@ -94,33 +84,7 @@ public class ProcessInfoTimerListener : TimerListenerBase, IDisposable, IChannel
         _process.Dispose();
     }
 
-    public async ValueTask OnReadResultAsync(CancellationToken cancellationToken)
-    {
-        try
-        {
-            // Keep the reader alive across Stop/Restart. Cancellation owns its lifetime.
-            while (await _channel.Reader.WaitToReadAsync(cancellationToken))
-            {
-                while (_channel.Reader.TryRead(out var value))
-                {
-                    if (_onEventEmit != null)
-                    {
-                        try
-                        {
-                            await _onEventEmit.Invoke(value);
-                        }
-                        catch (Exception ex)
-                        {
-                            _onEventError.Invoke(ex);
-                        }
-                    }
-                }
-            }
-        }
-        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
-        {
-        }
-    }
+    public ValueTask OnReadResultAsync(CancellationToken cancellationToken) => _dispatcher.ReadAllAsync(cancellationToken);
 
     public override void EventCreatedHandler()
     {
@@ -146,7 +110,7 @@ public class ProcessInfoTimerListener : TimerListenerBase, IDisposable, IChannel
             var privateBytes = _process.PrivateMemorySize64;
             var stat = new ProcessInfoStatistics(date, _cpu, workingSet, privateBytes);
 
-            _channel.Writer.TryWrite(stat);
+            _dispatcher.TryWrite(stat);
         }
         catch (Exception ex)
         {

--- a/src/ClrProfiler/TimerListeners/ThreadInfoTimerListener.cs
+++ b/src/ClrProfiler/TimerListeners/ThreadInfoTimerListener.cs
@@ -12,17 +12,15 @@ public class ThreadInfoTimerListener : TimerListenerBase, IDisposable, IChannelR
 
     public ChannelReader<ThreadInfoStatistics>? Reader { get; set; }
 
-    private readonly Channel<ThreadInfoStatistics> _channel;
-    private readonly Func<ThreadInfoStatistics, Task> _onEventEmit;
+    private readonly BoundedChannelDispatcher<ThreadInfoStatistics> _dispatcher;
     private readonly Action<Exception> _onEventError;
     private readonly TimeSpan _dueTime;
     private readonly TimeSpan _intervalPeriod;
-    private long _droppedEventCount;
 
     /// <summary>
     /// Gets the cumulative number of samples evicted from the bounded delivery channel.
     /// </summary>
-    public long DroppedEventCount => Volatile.Read(ref _droppedEventCount);
+    public long DroppedEventCount => _dispatcher.DroppedEventCount;
 
     /// <summary>
     /// Constructor
@@ -33,19 +31,11 @@ public class ThreadInfoTimerListener : TimerListenerBase, IDisposable, IChannelR
     /// <param name="intervalPeriod">The time inteval between the invocation of timer.</param>
     public ThreadInfoTimerListener(Func<ThreadInfoStatistics, Task> onEventEmit, Action<Exception> onEventError, TimeSpan dueTime, TimeSpan intervalPeriod)
     {
-        _onEventEmit = onEventEmit;
         _onEventError = onEventError;
         _dueTime = dueTime;
         _intervalPeriod = intervalPeriod;
-        _channel = Channel.CreateBounded<ThreadInfoStatistics>(new BoundedChannelOptions(50)
-        {
-            SingleWriter = true,
-            SingleReader = true,
-            FullMode = BoundedChannelFullMode.DropOldest,
-        }, OnItemDropped);
+        _dispatcher = new BoundedChannelDispatcher<ThreadInfoStatistics>(50, singleWriter: true, onEventEmit, onEventError);
     }
-
-    private void OnItemDropped(ThreadInfoStatistics _) => Interlocked.Increment(ref _droppedEventCount);
 
     protected override void OnEventWritten()
     {
@@ -84,33 +74,7 @@ public class ThreadInfoTimerListener : TimerListenerBase, IDisposable, IChannelR
         timer?.Dispose();
     }
 
-    public async ValueTask OnReadResultAsync(CancellationToken cancellationToken)
-    {
-        try
-        {
-            // Keep the reader alive across Stop/Restart. Cancellation owns its lifetime.
-            while (await _channel.Reader.WaitToReadAsync(cancellationToken))
-            {
-                while (_channel.Reader.TryRead(out var value))
-                {
-                    if (_onEventEmit != null)
-                    {
-                        try
-                        {
-                            await _onEventEmit.Invoke(value);
-                        }
-                        catch (Exception ex)
-                        {
-                            _onEventError.Invoke(ex);
-                        }
-                    }
-                }
-            }
-        }
-        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
-        {
-        }
-    }
+    public ValueTask OnReadResultAsync(CancellationToken cancellationToken) => _dispatcher.ReadAllAsync(cancellationToken);
 
     public override void EventCreatedHandler()
     {
@@ -127,7 +91,7 @@ public class ThreadInfoTimerListener : TimerListenerBase, IDisposable, IChannelR
             var lockContentionCount = Monitor.LockContentionCount;
             var stat = new ThreadInfoStatistics(date, availableWorkerThreads, availableCompletionPortThreads, maxWorkerThreads, maxCompletionPortThreads, threadCount, queueLength, completedItemsCount, lockContentionCount);
 
-            _channel.Writer.TryWrite(stat);
+            _dispatcher.TryWrite(stat);
         }
         catch (Exception ex)
         {


### PR DESCRIPTION
## Summary

- Introduce a shared bounded-channel dispatcher for GC, ThreadPool, and timer listeners.
- Centralize drop counting, ordered callback dispatch, exception handling, and cancellation.
- Remove duplicated reader and channel implementations without changing public APIs.

## Details

The existing Task-based callback APIs remain unchanged to preserve compatibility. Listener reader methods continue returning `ValueTask` and now delegate directly to the shared dispatcher, avoiding redundant async state machines.

## Benchmark / Verification

- Hot-path allocation regression test remains at **0 B**
- **93 tests passed**
- Release build passed for net8.0, net9.0, and net10.0 with **0 warnings**
- NuGet packaging passed