### PR TITLE
feat: add feature mask to handle which handler to use.

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,24 @@ tracker.StartTracker();
 
 Now you are ready to use ClrTracker on your application. Metrics will be sent to Datadog by dogstatsd.
 
+### Select instrumentation
+
+All instrumentation remains enabled by default. For lower overhead, select only the CLR events and timer samples your application consumes:
+
+```cs
+using var tracker = new ClrTracker(loggerFactory, new ClrTrackerOptions
+{
+    TrackerType = ClrTrackerType.Datadog,
+    EnabledFeatures = ProfilerFeature.GCEvent
+        | ProfilerFeature.ThreadPoolEvent
+        | ProfilerFeature.ContentionEvent,
+});
+tracker.EnableTracker();
+tracker.StartTracker();
+```
+
+Unselected features do not create a listener, subscribe to runtime events, start a reader, or create a timer. The same `EnabledFeatures` option is available on `ProfilerTrackerOptions` when using the core package directly.
+
 ## Debugging
 
 If you want debug behaviour, use ClrTrackerType.Logger instead. This will log metrics to ILogger.Debug.

--- a/src/ClrProfiler.DatadogTracing/ClrTracker.cs
+++ b/src/ClrProfiler.DatadogTracing/ClrTracker.cs
@@ -60,6 +60,7 @@ public class ClrTracker : IDisposable
                 ClrTrackerType.Custom when _options.CustomHandler is null => throw new ArgumentException($"{nameof(ClrTrackerType.Custom)}: {_options.CustomHandler} is null, you must set custom Handler."),
                 _ => throw new NotImplementedException($"{nameof(ClrTrackerType)}: {_options.TrackerType} not implemented."),
             };
+            profilerOptions.EnabledFeatures = _options.EnabledFeatures;
 
             _profilerTracker = new ProfilerTracker(profilerOptions);
             _enabled = true;
@@ -136,6 +137,11 @@ public class ClrTracker : IDisposable
             ProcessInfoTimerCallback = (loggerTrackerHandler.OnProcessInfoTimerAsync, loggerTrackerHandler.OnException),
             ThreadInfoTimerCallback = (loggerTrackerHandler.OnThreadInfoTimerAsync, loggerTrackerHandler.OnException),
         };
+    }
+
+    internal void Status(Action<(string Name, bool Enabled)> action)
+    {
+        _profilerTracker?.Status(action);
     }
 
     public void Dispose()

--- a/src/ClrProfiler.DatadogTracing/ClrTracker.cs
+++ b/src/ClrProfiler.DatadogTracing/ClrTracker.cs
@@ -139,9 +139,23 @@ public class ClrTracker : IDisposable
         };
     }
 
-    internal void Status(Action<(string Name, bool Enabled)> action)
+    internal int ProfilerCount
     {
-        _profilerTracker?.Status(action);
+        get
+        {
+            lock (_lifecycleLock)
+            {
+                ObjectDisposedException.ThrowIf(_disposed, this);
+                if (!_enabled)
+                {
+                    return 0;
+                }
+
+                var profilerCount = 0;
+                _profilerTracker!.Status(_ => profilerCount++);
+                return profilerCount;
+            }
+        }
     }
 
     public void Dispose()

--- a/src/ClrProfiler.DatadogTracing/ClrTrackerOptions.cs
+++ b/src/ClrProfiler.DatadogTracing/ClrTrackerOptions.cs
@@ -8,6 +8,10 @@ public record ClrTrackerOptions
     };
 
     /// <summary>
+    /// Selects the CLR instrumentation to create and run. Defaults to all features for compatibility.
+    /// </summary>
+    public ProfilerFeature EnabledFeatures { get; init; } = ProfilerFeature.All;
+    /// <summary>
     /// Select the type of ClrTracker to use. If Custom is selected, CustomHandler must be set.
     /// </summary>
     public required ClrTrackerType TrackerType { get; init; }

--- a/src/ClrProfiler/ProfilerFeature.cs
+++ b/src/ClrProfiler/ProfilerFeature.cs
@@ -1,0 +1,17 @@
+namespace ClrProfiler;
+
+/// <summary>
+/// CLR instrumentation that can be enabled by <see cref="ProfilerTracker"/>.
+/// </summary>
+[Flags]
+public enum ProfilerFeature
+{
+    None = 0,
+    GCEvent = 1 << 0,
+    ThreadPoolEvent = 1 << 1,
+    ContentionEvent = 1 << 2,
+    ThreadInfoTimer = 1 << 3,
+    GCInfoTimer = 1 << 4,
+    ProcessInfoTimer = 1 << 5,
+    All = GCEvent | ThreadPoolEvent | ContentionEvent | ThreadInfoTimer | GCInfoTimer | ProcessInfoTimer,
+}

--- a/src/ClrProfiler/ProfilerTracker.cs
+++ b/src/ClrProfiler/ProfilerTracker.cs
@@ -8,6 +8,11 @@ namespace ClrProfiler;
 public class ProfilerTrackerOptions
 {
     /// <summary>
+    /// Gets or sets the instrumentation to create and run. Defaults to all features for compatibility.
+    /// </summary>
+    public ProfilerFeature EnabledFeatures { get; set; } = ProfilerFeature.All;
+
+    /// <summary>
     /// CancellationTokenSource to cancel reading event channel.
     /// </summary>
     public CancellationTokenSource CancellationTokenSource { get; set; } = new CancellationTokenSource();
@@ -62,16 +67,38 @@ public class ProfilerTracker : IDisposable
     public ProfilerTracker(ProfilerTrackerOptions? options = null)
     {
         this.options = options ?? new ProfilerTrackerOptions();
-        profilerStats = [
-            // event
-            new GCEventProfiler(this.options.GCEventCallback.OnSuccess, this.options.GCEventCallback.OnError),
-            new ThreadPoolEventProfiler(this.options.ThreadPoolEventCallback.OnSuccess, this.options.ThreadPoolEventCallback.OnError),
-            new ContentionEventProfiler(this.options.ContentionEventCallback.OnSuccess, this.options.ContentionEventCallback.OnError),
-            // timer
-            new ThreadInfoTimerProfiler(this.options.ThreadInfoTimerCallback.OnSuccess, this.options.ThreadInfoTimerCallback.OnError, this.options.TimerOption),
-            new GCInfoTimerProfiler(this.options.GCInfoTimerCallback.OnSuccess, this.options.GCInfoTimerCallback.OnError, this.options.TimerOption),
-            new ProcessInfoTimerProfiler(this.options.ProcessInfoTimerCallback.OnSuccess, this.options.ProcessInfoTimerCallback.OnError, this.options.TimerOption),
-        ];
+        var enabledFeatures = this.options.EnabledFeatures;
+        if ((enabledFeatures & ~ProfilerFeature.All) != 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(ProfilerTrackerOptions.EnabledFeatures), enabledFeatures, "Unknown profiler feature flags were specified.");
+        }
+
+        var profilers = new List<IProfiler>(6);
+        if ((enabledFeatures & ProfilerFeature.GCEvent) != 0)
+        {
+            profilers.Add(new GCEventProfiler(this.options.GCEventCallback.OnSuccess, this.options.GCEventCallback.OnError));
+        }
+        if ((enabledFeatures & ProfilerFeature.ThreadPoolEvent) != 0)
+        {
+            profilers.Add(new ThreadPoolEventProfiler(this.options.ThreadPoolEventCallback.OnSuccess, this.options.ThreadPoolEventCallback.OnError));
+        }
+        if ((enabledFeatures & ProfilerFeature.ContentionEvent) != 0)
+        {
+            profilers.Add(new ContentionEventProfiler(this.options.ContentionEventCallback.OnSuccess, this.options.ContentionEventCallback.OnError));
+        }
+        if ((enabledFeatures & ProfilerFeature.ThreadInfoTimer) != 0)
+        {
+            profilers.Add(new ThreadInfoTimerProfiler(this.options.ThreadInfoTimerCallback.OnSuccess, this.options.ThreadInfoTimerCallback.OnError, this.options.TimerOption));
+        }
+        if ((enabledFeatures & ProfilerFeature.GCInfoTimer) != 0)
+        {
+            profilers.Add(new GCInfoTimerProfiler(this.options.GCInfoTimerCallback.OnSuccess, this.options.GCInfoTimerCallback.OnError, this.options.TimerOption));
+        }
+        if ((enabledFeatures & ProfilerFeature.ProcessInfoTimer) != 0)
+        {
+            profilers.Add(new ProcessInfoTimerProfiler(this.options.ProcessInfoTimerCallback.OnSuccess, this.options.ProcessInfoTimerCallback.OnError, this.options.TimerOption));
+        }
+        profilerStats = profilers.ToArray();
         readerTasks = new Task?[profilerStats.Length];
     }
 

--- a/src/ClrProfiler/ProfilerTracker.cs
+++ b/src/ClrProfiler/ProfilerTracker.cs
@@ -103,6 +103,14 @@ public class ProfilerTracker : IDisposable
         {
             profilerStats[profilerIndex++] = new ProcessInfoTimerProfiler(this.options.ProcessInfoTimerCallback.OnSuccess, this.options.ProcessInfoTimerCallback.OnError, this.options.TimerOption);
         }
+        if (profilerIndex != profilerStats.Length)
+        {
+            for (var i = 0; i < profilerIndex; i++)
+            {
+                profilerStats[i].Dispose();
+            }
+            throw new InvalidOperationException($"Profiler feature mapping is incomplete. Expected {profilerStats.Length} profilers but created {profilerIndex}.");
+        }
         readerTasks = new Task?[profilerStats.Length];
     }
 

--- a/src/ClrProfiler/ProfilerTracker.cs
+++ b/src/ClrProfiler/ProfilerTracker.cs
@@ -1,4 +1,5 @@
 using ClrProfiler.Statistics;
+using System.Numerics;
 
 namespace ClrProfiler;
 
@@ -73,32 +74,35 @@ public class ProfilerTracker : IDisposable
             throw new ArgumentOutOfRangeException(nameof(ProfilerTrackerOptions.EnabledFeatures), enabledFeatures, "Unknown profiler feature flags were specified.");
         }
 
-        var profilers = new List<IProfiler>(6);
+        var enabledFeatureCount = BitOperations.PopCount((uint)enabledFeatures);
+        profilerStats = enabledFeatureCount == 0
+            ? Array.Empty<IProfiler>()
+            : new IProfiler[enabledFeatureCount];
+        var profilerIndex = 0;
         if ((enabledFeatures & ProfilerFeature.GCEvent) != 0)
         {
-            profilers.Add(new GCEventProfiler(this.options.GCEventCallback.OnSuccess, this.options.GCEventCallback.OnError));
+            profilerStats[profilerIndex++] = new GCEventProfiler(this.options.GCEventCallback.OnSuccess, this.options.GCEventCallback.OnError);
         }
         if ((enabledFeatures & ProfilerFeature.ThreadPoolEvent) != 0)
         {
-            profilers.Add(new ThreadPoolEventProfiler(this.options.ThreadPoolEventCallback.OnSuccess, this.options.ThreadPoolEventCallback.OnError));
+            profilerStats[profilerIndex++] = new ThreadPoolEventProfiler(this.options.ThreadPoolEventCallback.OnSuccess, this.options.ThreadPoolEventCallback.OnError);
         }
         if ((enabledFeatures & ProfilerFeature.ContentionEvent) != 0)
         {
-            profilers.Add(new ContentionEventProfiler(this.options.ContentionEventCallback.OnSuccess, this.options.ContentionEventCallback.OnError));
+            profilerStats[profilerIndex++] = new ContentionEventProfiler(this.options.ContentionEventCallback.OnSuccess, this.options.ContentionEventCallback.OnError);
         }
         if ((enabledFeatures & ProfilerFeature.ThreadInfoTimer) != 0)
         {
-            profilers.Add(new ThreadInfoTimerProfiler(this.options.ThreadInfoTimerCallback.OnSuccess, this.options.ThreadInfoTimerCallback.OnError, this.options.TimerOption));
+            profilerStats[profilerIndex++] = new ThreadInfoTimerProfiler(this.options.ThreadInfoTimerCallback.OnSuccess, this.options.ThreadInfoTimerCallback.OnError, this.options.TimerOption);
         }
         if ((enabledFeatures & ProfilerFeature.GCInfoTimer) != 0)
         {
-            profilers.Add(new GCInfoTimerProfiler(this.options.GCInfoTimerCallback.OnSuccess, this.options.GCInfoTimerCallback.OnError, this.options.TimerOption));
+            profilerStats[profilerIndex++] = new GCInfoTimerProfiler(this.options.GCInfoTimerCallback.OnSuccess, this.options.GCInfoTimerCallback.OnError, this.options.TimerOption);
         }
         if ((enabledFeatures & ProfilerFeature.ProcessInfoTimer) != 0)
         {
-            profilers.Add(new ProcessInfoTimerProfiler(this.options.ProcessInfoTimerCallback.OnSuccess, this.options.ProcessInfoTimerCallback.OnError, this.options.TimerOption));
+            profilerStats[profilerIndex++] = new ProcessInfoTimerProfiler(this.options.ProcessInfoTimerCallback.OnSuccess, this.options.ProcessInfoTimerCallback.OnError, this.options.TimerOption);
         }
-        profilerStats = profilers.ToArray();
         readerTasks = new Task?[profilerStats.Length];
     }
 

--- a/tests/CleProfiler.DatadogTracing.UnitTest/ClrTrackerMetricTagsInitializationTest.cs
+++ b/tests/CleProfiler.DatadogTracing.UnitTest/ClrTrackerMetricTagsInitializationTest.cs
@@ -18,12 +18,24 @@ public class ClrTrackerMetricTagsInitializationTest
                 EnabledFeatures = ProfilerFeature.ThreadPoolEvent,
             },
             static () => { });
-        var names = new List<string>();
+        tracker.EnableTracker();
+
+        await Assert.That(tracker.ProfilerCount).IsEqualTo(1);
+    }
+
+    [Test]
+    public async Task ProfilerCount_AfterDispose_ThrowsObjectDisposedException()
+    {
+        using var loggerFactory = TestHelpers.CreateLoggerFactory();
+        var tracker = new ClrTracker(
+            loggerFactory,
+            new ClrTrackerOptions { TrackerType = ClrTrackerType.Logger },
+            static () => { });
 
         tracker.EnableTracker();
-        tracker.Status(status => names.Add(status.Name));
+        tracker.Dispose();
 
-        await Assert.That(names).IsEquivalentTo([nameof(ThreadPoolEventProfiler)]);
+        await Assert.That(() => tracker.ProfilerCount).Throws<ObjectDisposedException>();
     }
 
     [Test]

--- a/tests/CleProfiler.DatadogTracing.UnitTest/ClrTrackerMetricTagsInitializationTest.cs
+++ b/tests/CleProfiler.DatadogTracing.UnitTest/ClrTrackerMetricTagsInitializationTest.cs
@@ -1,3 +1,4 @@
+using ClrProfiler;
 using ClrProfiler.DatadogTracing;
 
 namespace CleProfiler.DatadogTracing.UnitTest;
@@ -5,6 +6,26 @@ namespace CleProfiler.DatadogTracing.UnitTest;
 [NotInParallel]
 public class ClrTrackerMetricTagsInitializationTest
 {
+    [Test]
+    public async Task EnableTracker_ForwardsEnabledFeaturesToProfilerTracker()
+    {
+        using var loggerFactory = TestHelpers.CreateLoggerFactory();
+        using var tracker = new ClrTracker(
+            loggerFactory,
+            new ClrTrackerOptions
+            {
+                TrackerType = ClrTrackerType.Logger,
+                EnabledFeatures = ProfilerFeature.ThreadPoolEvent,
+            },
+            static () => { });
+        var names = new List<string>();
+
+        tracker.EnableTracker();
+        tracker.Status(status => names.Add(status.Name));
+
+        await Assert.That(names).IsEquivalentTo([nameof(ThreadPoolEventProfiler)]);
+    }
+
     [Test]
     [Arguments(ClrTrackerType.Datadog)]
     [Arguments(ClrTrackerType.Logger)]

--- a/tests/ClrProfiler.UnitTest/ProfilerLifecycleTest.cs
+++ b/tests/ClrProfiler.UnitTest/ProfilerLifecycleTest.cs
@@ -10,6 +10,44 @@ public class ProfilerLifecycleTest
     private static readonly TimeSpan TestTimeout = TimeSpan.FromSeconds(5);
 
     [Test]
+    public async Task TrackerCreatesOnlyEnabledProfilers()
+    {
+        using var cts = new CancellationTokenSource();
+        using var tracker = new ProfilerTracker(new ProfilerTrackerOptions
+        {
+            CancellationTokenSource = cts,
+            EnabledFeatures = ProfilerFeature.GCEvent | ProfilerFeature.ThreadInfoTimer,
+        });
+        var names = new List<string>();
+
+        tracker.Status(status => names.Add(status.Name));
+
+        await Assert.That(names).IsEquivalentTo([
+            nameof(GCEventProfiler),
+            nameof(ThreadInfoTimerProfiler),
+        ]);
+    }
+
+    [Test]
+    public async Task TrackerEnablesAllProfilersByDefault()
+    {
+        using var cts = new CancellationTokenSource();
+        using var tracker = new ProfilerTracker(new ProfilerTrackerOptions { CancellationTokenSource = cts });
+        var names = new List<string>();
+
+        tracker.Status(status => names.Add(status.Name));
+
+        await Assert.That(names).IsEquivalentTo([
+            nameof(GCEventProfiler),
+            nameof(ThreadPoolEventProfiler),
+            nameof(ContentionEventProfiler),
+            nameof(ThreadInfoTimerProfiler),
+            nameof(GCInfoTimerProfiler),
+            nameof(ProcessInfoTimerProfiler),
+        ]);
+    }
+
+    [Test]
     public async Task TrackerLifecycleTransitionsAreIdempotent()
     {
         using var firstCts = new CancellationTokenSource();


### PR DESCRIPTION
## Summary

- Add a `ProfilerFeature` flag mask to core and Datadog tracker options.
- Create only the selected event listeners and timer profilers.
- Keep all instrumentation enabled by default for backward compatibility.
- Add tests and documentation for selective instrumentation.

## Motivation

Previously, every listener and timer started even when its callback was unused. Selective instrumentation avoids unnecessary EventSource subscriptions, payload parsing, channel writes, reader wake-ups, and timers, reducing application overhead without adding branches to event hot paths.