### PR TITLE
feat: add AdditionalProfilerFactories to register own Profiler

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ tracker.StartTracker();
 
 Unselected features do not create a listener, subscribe to runtime events, start a reader, or create a timer. The same `EnabledFeatures` option is available on `ProfilerTrackerOptions` when using the core package directly.
 
-### Add custom profilers
+### Add custom instrumentation
 
 Implement `IProfiler` to monitor another `EventSource`, CLR event, or timer source, then register a factory alongside the built-in instrumentation:
 
@@ -76,9 +76,11 @@ using var tracker = new ClrTracker(loggerFactory, new ClrTrackerOptions
         () => new MyEventSourceProfiler(...),
     ],
 });
+tracker.EnableTracker();
+tracker.StartTracker();
 ```
 
-Each factory is invoked once when the tracker is enabled. The tracker owns the returned profiler and includes it in `Start`, `Stop`, `Restart`, `Cancel`, and `Dispose`. Custom profilers remain responsible for bounded, non-blocking event processing and callback error handling.
+Each factory is invoked once when `ProfilerTracker` is constructed, which happens during `ClrTracker.EnableTracker()` when using the Datadog adapter. The tracker owns the returned profiler and includes it in `Start`, `Stop`, `Restart`, `Cancel`, and `Dispose`. Custom profilers remain responsible for bounded, non-blocking event processing and callback error handling.
 
 ## Debugging
 
@@ -98,7 +100,7 @@ Metric tags are precomputed when the tracker is enabled, before CLR listeners st
 
 ## Custom Profiling
 
-For advanced scenarios, you can implement custom profiling by creating your own callback handler. Implement the `IClrTrackerCallbackHandler` interface to define custom behavior for each CLR event type.
+This section customizes handling for the built-in instrumentation; use `AdditionalProfilerFactories` above to add new instrumentation. Implement the `IClrTrackerCallbackHandler` interface to define custom behavior for each built-in CLR event type.
 
 ```cs
 public class MyCustomTrackerHandler : IClrTrackerCallbackHandler

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ tracker.EnableTracker();
 tracker.StartTracker();
 ```
 
-Each factory is invoked once when `ProfilerTracker` is constructed, which happens during `ClrTracker.EnableTracker()` when using the Datadog adapter. The tracker owns the returned profiler and includes it in `Start`, `Stop`, `Restart`, `Cancel`, and `Dispose`. Custom profilers remain responsible for bounded, non-blocking event processing and callback error handling.
+Each factory is invoked once when `ProfilerTracker` is constructed. When using `ClrTracker`, this happens inside `EnableTracker()` for Datadog, Logger, and Custom tracker types. The tracker owns the returned profiler and includes it in `Start`, `Stop`, `Restart`, `Cancel`, and `Dispose`. Custom profilers remain responsible for bounded, non-blocking event processing and callback error handling.
 
 ## Debugging
 

--- a/README.md
+++ b/README.md
@@ -62,6 +62,24 @@ tracker.StartTracker();
 
 Unselected features do not create a listener, subscribe to runtime events, start a reader, or create a timer. The same `EnabledFeatures` option is available on `ProfilerTrackerOptions` when using the core package directly.
 
+### Add custom profilers
+
+Implement `IProfiler` to monitor another `EventSource`, CLR event, or timer source, then register a factory alongside the built-in instrumentation:
+
+```cs
+using var tracker = new ClrTracker(loggerFactory, new ClrTrackerOptions
+{
+    TrackerType = ClrTrackerType.Datadog,
+    EnabledFeatures = ProfilerFeature.GCEvent,
+    AdditionalProfilerFactories =
+    [
+        () => new MyEventSourceProfiler(...),
+    ],
+});
+```
+
+Each factory is invoked once when the tracker is enabled. The tracker owns the returned profiler and includes it in `Start`, `Stop`, `Restart`, `Cancel`, and `Dispose`. Custom profilers remain responsible for bounded, non-blocking event processing and callback error handling.
+
 ## Debugging
 
 If you want debug behaviour, use ClrTrackerType.Logger instead. This will log metrics to ILogger.Debug.

--- a/src/ClrProfiler.DatadogTracing/ClrTracker.cs
+++ b/src/ClrProfiler.DatadogTracing/ClrTracker.cs
@@ -61,6 +61,7 @@ public class ClrTracker : IDisposable
                 _ => throw new NotImplementedException($"{nameof(ClrTrackerType)}: {_options.TrackerType} not implemented."),
             };
             profilerOptions.EnabledFeatures = _options.EnabledFeatures;
+            profilerOptions.AdditionalProfilerFactories = _options.AdditionalProfilerFactories;
 
             _profilerTracker = new ProfilerTracker(profilerOptions);
             _enabled = true;

--- a/src/ClrProfiler.DatadogTracing/ClrTrackerOptions.cs
+++ b/src/ClrProfiler.DatadogTracing/ClrTrackerOptions.cs
@@ -12,6 +12,10 @@ public record ClrTrackerOptions
     /// </summary>
     public ProfilerFeature EnabledFeatures { get; init; } = ProfilerFeature.All;
     /// <summary>
+    /// Gets additional profiler factories whose instances are managed and disposed by the tracker.
+    /// </summary>
+    public IReadOnlyList<Func<IProfiler>> AdditionalProfilerFactories { get; init; } = Array.Empty<Func<IProfiler>>();
+    /// <summary>
     /// Select the type of ClrTracker to use. If Custom is selected, CustomHandler must be set.
     /// </summary>
     public required ClrTrackerType TrackerType { get; init; }

--- a/src/ClrProfiler/ProfilerTracker.cs
+++ b/src/ClrProfiler/ProfilerTracker.cs
@@ -14,6 +14,12 @@ public class ProfilerTrackerOptions
     public ProfilerFeature EnabledFeatures { get; set; } = ProfilerFeature.All;
 
     /// <summary>
+    /// Gets or sets factories for additional profilers managed by this tracker. Each factory is
+    /// invoked once during construction, and the tracker owns and disposes the returned profiler.
+    /// </summary>
+    public IReadOnlyList<Func<IProfiler>> AdditionalProfilerFactories { get; set; } = Array.Empty<Func<IProfiler>>();
+
+    /// <summary>
     /// CancellationTokenSource to cancel reading event channel.
     /// </summary>
     public CancellationTokenSource CancellationTokenSource { get; set; } = new CancellationTokenSource();
@@ -74,44 +80,79 @@ public class ProfilerTracker : IDisposable
             throw new ArgumentOutOfRangeException(nameof(ProfilerTrackerOptions.EnabledFeatures), enabledFeatures, "Unknown profiler feature flags were specified.");
         }
 
-        var enabledFeatureCount = BitOperations.PopCount((uint)enabledFeatures);
-        profilerStats = enabledFeatureCount == 0
+        var additionalProfilerFactories = this.options.AdditionalProfilerFactories
+            ?? throw new ArgumentNullException(nameof(ProfilerTrackerOptions.AdditionalProfilerFactories));
+        var profilerCount = checked(BitOperations.PopCount((uint)enabledFeatures) + additionalProfilerFactories.Count);
+        profilerStats = profilerCount == 0
             ? Array.Empty<IProfiler>()
-            : new IProfiler[enabledFeatureCount];
+            : new IProfiler[profilerCount];
         var profilerIndex = 0;
-        if ((enabledFeatures & ProfilerFeature.GCEvent) != 0)
+        try
         {
-            profilerStats[profilerIndex++] = new GCEventProfiler(this.options.GCEventCallback.OnSuccess, this.options.GCEventCallback.OnError);
-        }
-        if ((enabledFeatures & ProfilerFeature.ThreadPoolEvent) != 0)
-        {
-            profilerStats[profilerIndex++] = new ThreadPoolEventProfiler(this.options.ThreadPoolEventCallback.OnSuccess, this.options.ThreadPoolEventCallback.OnError);
-        }
-        if ((enabledFeatures & ProfilerFeature.ContentionEvent) != 0)
-        {
-            profilerStats[profilerIndex++] = new ContentionEventProfiler(this.options.ContentionEventCallback.OnSuccess, this.options.ContentionEventCallback.OnError);
-        }
-        if ((enabledFeatures & ProfilerFeature.ThreadInfoTimer) != 0)
-        {
-            profilerStats[profilerIndex++] = new ThreadInfoTimerProfiler(this.options.ThreadInfoTimerCallback.OnSuccess, this.options.ThreadInfoTimerCallback.OnError, this.options.TimerOption);
-        }
-        if ((enabledFeatures & ProfilerFeature.GCInfoTimer) != 0)
-        {
-            profilerStats[profilerIndex++] = new GCInfoTimerProfiler(this.options.GCInfoTimerCallback.OnSuccess, this.options.GCInfoTimerCallback.OnError, this.options.TimerOption);
-        }
-        if ((enabledFeatures & ProfilerFeature.ProcessInfoTimer) != 0)
-        {
-            profilerStats[profilerIndex++] = new ProcessInfoTimerProfiler(this.options.ProcessInfoTimerCallback.OnSuccess, this.options.ProcessInfoTimerCallback.OnError, this.options.TimerOption);
-        }
-        if (profilerIndex != profilerStats.Length)
-        {
-            for (var i = 0; i < profilerIndex; i++)
+            if ((enabledFeatures & ProfilerFeature.GCEvent) != 0)
             {
-                profilerStats[i].Dispose();
+                profilerStats[profilerIndex] = new GCEventProfiler(this.options.GCEventCallback.OnSuccess, this.options.GCEventCallback.OnError);
+                profilerIndex++;
             }
-            throw new InvalidOperationException($"Profiler feature mapping is incomplete. Expected {profilerStats.Length} profilers but created {profilerIndex}.");
+            if ((enabledFeatures & ProfilerFeature.ThreadPoolEvent) != 0)
+            {
+                profilerStats[profilerIndex] = new ThreadPoolEventProfiler(this.options.ThreadPoolEventCallback.OnSuccess, this.options.ThreadPoolEventCallback.OnError);
+                profilerIndex++;
+            }
+            if ((enabledFeatures & ProfilerFeature.ContentionEvent) != 0)
+            {
+                profilerStats[profilerIndex] = new ContentionEventProfiler(this.options.ContentionEventCallback.OnSuccess, this.options.ContentionEventCallback.OnError);
+                profilerIndex++;
+            }
+            if ((enabledFeatures & ProfilerFeature.ThreadInfoTimer) != 0)
+            {
+                profilerStats[profilerIndex] = new ThreadInfoTimerProfiler(this.options.ThreadInfoTimerCallback.OnSuccess, this.options.ThreadInfoTimerCallback.OnError, this.options.TimerOption);
+                profilerIndex++;
+            }
+            if ((enabledFeatures & ProfilerFeature.GCInfoTimer) != 0)
+            {
+                profilerStats[profilerIndex] = new GCInfoTimerProfiler(this.options.GCInfoTimerCallback.OnSuccess, this.options.GCInfoTimerCallback.OnError, this.options.TimerOption);
+                profilerIndex++;
+            }
+            if ((enabledFeatures & ProfilerFeature.ProcessInfoTimer) != 0)
+            {
+                profilerStats[profilerIndex] = new ProcessInfoTimerProfiler(this.options.ProcessInfoTimerCallback.OnSuccess, this.options.ProcessInfoTimerCallback.OnError, this.options.TimerOption);
+                profilerIndex++;
+            }
+            for (var i = 0; i < additionalProfilerFactories.Count; i++)
+            {
+                var factory = additionalProfilerFactories[i]
+                    ?? throw new ArgumentException("An additional profiler factory cannot be null.", nameof(ProfilerTrackerOptions.AdditionalProfilerFactories));
+                profilerStats[profilerIndex] = factory()
+                    ?? throw new InvalidOperationException("An additional profiler factory returned null.");
+                profilerIndex++;
+            }
+            if (profilerIndex != profilerStats.Length)
+            {
+                throw new InvalidOperationException($"Profiler mapping is incomplete. Expected {profilerStats.Length} profilers but created {profilerIndex}.");
+            }
+        }
+        catch
+        {
+            DisposeCreatedProfilers(profilerStats, profilerIndex);
+            throw;
         }
         readerTasks = new Task?[profilerStats.Length];
+    }
+
+    private static void DisposeCreatedProfilers(IProfiler[] profilers, int count)
+    {
+        for (var i = 0; i < count; i++)
+        {
+            try
+            {
+                profilers[i].Dispose();
+            }
+            catch
+            {
+                // Preserve the construction exception while best-effort cleanup continues.
+            }
+        }
     }
 
     internal ProfilerTracker(IProfiler[] profilers, ProfilerTrackerOptions? options = null)

--- a/src/ClrProfiler/ProfilerTracker.cs
+++ b/src/ClrProfiler/ProfilerTracker.cs
@@ -122,9 +122,9 @@ public class ProfilerTracker : IDisposable
             for (var i = 0; i < additionalProfilerFactories.Count; i++)
             {
                 var factory = additionalProfilerFactories[i]
-                    ?? throw new ArgumentException("An additional profiler factory cannot be null.", nameof(ProfilerTrackerOptions.AdditionalProfilerFactories));
+                    ?? throw new ArgumentException($"Additional profiler factory at index {i} cannot be null.", nameof(ProfilerTrackerOptions.AdditionalProfilerFactories));
                 profilerStats[profilerIndex] = factory()
-                    ?? throw new InvalidOperationException("An additional profiler factory returned null.");
+                    ?? throw new InvalidOperationException($"Additional profiler factory at index {i} returned null.");
                 profilerIndex++;
             }
             if (profilerIndex != profilerStats.Length)

--- a/tests/CleProfiler.DatadogTracing.UnitTest/ClrTrackerMetricTagsInitializationTest.cs
+++ b/tests/CleProfiler.DatadogTracing.UnitTest/ClrTrackerMetricTagsInitializationTest.cs
@@ -7,6 +7,42 @@ namespace CleProfiler.DatadogTracing.UnitTest;
 public class ClrTrackerMetricTagsInitializationTest
 {
     [Test]
+    public async Task EnableTracker_ManagesAdditionalProfilerLifecycle()
+    {
+        using var loggerFactory = TestHelpers.CreateLoggerFactory();
+        var profiler = new RecordingProfiler();
+        var factoryCallCount = 0;
+        using var tracker = new ClrTracker(
+            loggerFactory,
+            new ClrTrackerOptions
+            {
+                TrackerType = ClrTrackerType.Logger,
+                EnabledFeatures = ProfilerFeature.None,
+                AdditionalProfilerFactories =
+                [
+                    () =>
+                    {
+                        factoryCallCount++;
+                        return profiler;
+                    },
+                ],
+            },
+            static () => { });
+
+        tracker.EnableTracker();
+        tracker.StartTracker();
+        var profilerCount = tracker.ProfilerCount;
+        tracker.Dispose();
+
+        await Assert.That(factoryCallCount).IsEqualTo(1);
+        await Assert.That(profilerCount).IsEqualTo(1);
+        await Assert.That(profiler.StartCount).IsEqualTo(1);
+        await Assert.That(profiler.ReadCount).IsEqualTo(1);
+        await Assert.That(profiler.StopCount).IsEqualTo(1);
+        await Assert.That(profiler.DisposeCount).IsEqualTo(1);
+    }
+
+    [Test]
     public async Task EnableTracker_ForwardsEnabledFeaturesToProfilerTracker()
     {
         using var loggerFactory = TestHelpers.CreateLoggerFactory();
@@ -54,5 +90,37 @@ public class ClrTrackerMetricTagsInitializationTest
         tracker.EnableTracker();
 
         await Assert.That(initializationCount).IsEqualTo(1);
+    }
+
+    private sealed class RecordingProfiler : IProfiler
+    {
+        public string Name => nameof(RecordingProfiler);
+        public bool Enabled { get; private set; }
+        public int StartCount { get; private set; }
+        public int StopCount { get; private set; }
+        public int ReadCount { get; private set; }
+        public int DisposeCount { get; private set; }
+
+        public void Start()
+        {
+            Enabled = true;
+            StartCount++;
+        }
+
+        public void Restart() => Enabled = true;
+
+        public void Stop()
+        {
+            Enabled = false;
+            StopCount++;
+        }
+
+        public Task ReadResultAsync(CancellationToken cancellationToken)
+        {
+            ReadCount++;
+            return Task.CompletedTask;
+        }
+
+        public void Dispose() => DisposeCount++;
     }
 }

--- a/tests/ClrProfiler.UnitTest/ProfilerLifecycleTest.cs
+++ b/tests/ClrProfiler.UnitTest/ProfilerLifecycleTest.cs
@@ -103,6 +103,66 @@ public class ProfilerLifecycleTest
     }
 
     [Test]
+    public async Task TrackerReportsNullAdditionalProfilerFactoryIndex()
+    {
+        using var cts = new CancellationTokenSource();
+        var profiler = new RecordingProfiler();
+        ArgumentException? actualException = null;
+
+        try
+        {
+            _ = new ProfilerTracker(new ProfilerTrackerOptions
+            {
+                CancellationTokenSource = cts,
+                EnabledFeatures = ProfilerFeature.None,
+                AdditionalProfilerFactories =
+                [
+                    () => profiler,
+                    null!,
+                ],
+            });
+        }
+        catch (ArgumentException ex)
+        {
+            actualException = ex;
+        }
+
+        await Assert.That(actualException).IsNotNull();
+        await Assert.That(actualException!.Message).Contains("index 1");
+        await Assert.That(profiler.DisposeCount).IsEqualTo(1);
+    }
+
+    [Test]
+    public async Task TrackerReportsNullReturningAdditionalProfilerFactoryIndex()
+    {
+        using var cts = new CancellationTokenSource();
+        var profiler = new RecordingProfiler();
+        InvalidOperationException? actualException = null;
+
+        try
+        {
+            _ = new ProfilerTracker(new ProfilerTrackerOptions
+            {
+                CancellationTokenSource = cts,
+                EnabledFeatures = ProfilerFeature.None,
+                AdditionalProfilerFactories =
+                [
+                    () => profiler,
+                    () => null!,
+                ],
+            });
+        }
+        catch (InvalidOperationException ex)
+        {
+            actualException = ex;
+        }
+
+        await Assert.That(actualException).IsNotNull();
+        await Assert.That(actualException!.Message).Contains("index 1");
+        await Assert.That(profiler.DisposeCount).IsEqualTo(1);
+    }
+
+    [Test]
     public async Task TrackerLifecycleTransitionsAreIdempotent()
     {
         using var firstCts = new CancellationTokenSource();

--- a/tests/ClrProfiler.UnitTest/ProfilerLifecycleTest.cs
+++ b/tests/ClrProfiler.UnitTest/ProfilerLifecycleTest.cs
@@ -48,6 +48,61 @@ public class ProfilerLifecycleTest
     }
 
     [Test]
+    public async Task TrackerOwnsAdditionalProfilerLifecycle()
+    {
+        using var cts = new CancellationTokenSource();
+        var profiler = new RecordingProfiler();
+        var factoryCallCount = 0;
+        using var tracker = new ProfilerTracker(new ProfilerTrackerOptions
+        {
+            CancellationTokenSource = cts,
+            EnabledFeatures = ProfilerFeature.None,
+            AdditionalProfilerFactories =
+            [
+                () =>
+                {
+                    factoryCallCount++;
+                    return profiler;
+                },
+            ],
+        });
+        var names = new List<string>();
+
+        tracker.Status(status => names.Add(status.Name));
+        tracker.Start();
+        tracker.Dispose();
+
+        await Assert.That(factoryCallCount).IsEqualTo(1);
+        await Assert.That(names).IsEquivalentTo([nameof(RecordingProfiler)]);
+        await Assert.That(profiler.StartCount).IsEqualTo(1);
+        await Assert.That(profiler.ReadCount).IsEqualTo(1);
+        await Assert.That(profiler.StopCount).IsEqualTo(1);
+        await Assert.That(profiler.DisposeCount).IsEqualTo(1);
+    }
+
+    [Test]
+    public async Task TrackerDisposesCreatedProfilersWhenAdditionalFactoryThrows()
+    {
+        using var cts = new CancellationTokenSource();
+        var profiler = new RecordingProfiler();
+        var expectedException = new InvalidOperationException("factory failed");
+
+        void CreateTracker() => _ = new ProfilerTracker(new ProfilerTrackerOptions
+        {
+            CancellationTokenSource = cts,
+            EnabledFeatures = ProfilerFeature.None,
+            AdditionalProfilerFactories =
+            [
+                () => profiler,
+                () => throw expectedException,
+            ],
+        });
+
+        await Assert.That(CreateTracker).Throws<InvalidOperationException>();
+        await Assert.That(profiler.DisposeCount).IsEqualTo(1);
+    }
+
+    [Test]
     public async Task TrackerLifecycleTransitionsAreIdempotent()
     {
         using var firstCts = new CancellationTokenSource();
@@ -294,6 +349,7 @@ public class ProfilerLifecycleTest
         public int RestartCount { get; private set; }
         public int StopCount { get; private set; }
         public int ReadCount { get; private set; }
+        public int DisposeCount { get; private set; }
 
         public void Start()
         {
@@ -321,6 +377,7 @@ public class ProfilerLifecycleTest
 
         public void Dispose()
         {
+            DisposeCount++;
         }
     }
 


### PR DESCRIPTION
## Summary

- Add `AdditionalProfilerFactories` to `ProfilerTrackerOptions` and `ClrTrackerOptions`.
- Integrate custom `IProfiler` implementations into the existing tracker lifecycle.
- Clean up already-created profilers if a later factory fails.
- Document custom profiler registration in the README.

## Motivation

`ClrTrackerType.Custom` customizes how built-in statistics are handled, but it does not add new instrumentation. This change enables monitoring additional EventSources, CLR events, or timer sources while reusing the existing `Start`, `Stop`, `Restart`, `Cancel`, and `Dispose` lifecycle.

Factories are invoked once during tracker initialization, and the tracker owns the returned profiler instances.

## Usage

```csharp
using var tracker = new ClrTracker(loggerFactory, new ClrTrackerOptions
{
    TrackerType = ClrTrackerType.Datadog,
    EnabledFeatures = ProfilerFeature.GCEvent,
    AdditionalProfilerFactories =
    [
        () => new MyEventSourceProfiler(...),
    ],
});

tracker.EnableTracker();
tracker.StartTracker();
```